### PR TITLE
Fix size and sha256

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -63,8 +63,8 @@
           "type": "extra-data",
           "filename": "Minecraft.tar.gz",
           "url": "https://launcher.mojang.com/download/Minecraft.tar.gz",
-          "sha256": "61024d7573e82d8b4c730f01b7a74e4c925bfb62e2473570fe4b16a04df56816",
-          "size": 66992368
+          "sha256": "887214f4291e3e7b2e042840c2682af6c1a21a3296294b29ac1c63d4a00b467d",
+          "size": 66669820
         },
         {
           "type": "script",

--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -63,8 +63,8 @@
           "type": "extra-data",
           "filename": "Minecraft.tar.gz",
           "url": "https://launcher.mojang.com/download/Minecraft.tar.gz",
-          "sha256": "887214f4291e3e7b2e042840c2682af6c1a21a3296294b29ac1c63d4a00b467d",
-          "size": 66669820
+          "sha256": "7edfd08f1ecf15ec36a555b609a6c5f2e8504350b5c7ccb2392fd051d133e06d",
+          "size": 66565594
         },
         {
           "type": "script",


### PR DESCRIPTION
Resolves #9. Install and update should now be successful.

File retrieved from https://launcher.mojang.com/download/Minecraft.tar.gz.
`sha256` found by `sha256sum`.
`size` found by `du -b`.