### PR TITLE
Add openjdk8 extension point

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -13,6 +13,16 @@
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk11"
     ],
+    "add-extensions": {
+        "org.freedesktop.Sdk.Extension.openjdk8": {
+            "directory": "jdk8",
+            "version": "19.08",
+            "no-autodownload": true
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p /app/jdk8"
+    ],
     "finish-args": [
         "--persist=.minecraft",
         "--socket=x11",


### PR DESCRIPTION
Fixes #5

This way java 8 is usable by installing `org.freedesktop.Sdk.Extension.openjdk8` and running `flatpak override --env=JAVA_HOME=/app/jdk8/jvm/java-8-openjdk/jre com.mojang.Minecraft`

And since this extension is not auto-installed it won't increase the size for users that do not need java 8.