### PR TITLE
replace openjdk11/install.sh with openjdk8/install.sh

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -50,7 +50,7 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk11/install.sh"
+                "/usr/lib/sdk/openjdk8/install.sh"
             ]
         },
         {


### PR DESCRIPTION
Older versions of Minecraft like 1.8.9 can not connect to servers most likely because the Flatpak package uses OpenJDK 11

error when connecting to servers on 1.8.9:
> Internal Exception: java.lang.RuntimeException: Unable to access address of buffer

1.8.9 is still popular among people in the PVP community because it is the last version before the combat update (1.9) that many people do not enjoy playing on.
Additionally, 1.8.9 uses less system resources because it has less features than the latest versions, possibly allowing a smoother game play experience.

**Solution:** replace OpenJDK 11 with OpenJDK 8. 

See Issue: #70 