### PR TITLE
[WIP] Update Minecraft.tar.gz to 921

### DIFF
--- a/com.mojang.Minecraft.appdata.xml
+++ b/com.mojang.Minecraft.appdata.xml
@@ -51,6 +51,7 @@
   <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Mojang AB</developer_name>
   <releases>
+    <release version="921" date="2021-03-15"/>
     <release version="2.2.1867" date="2021-02-22"/>
     <release version="2.2.1441" date="2021-02-01"/>
     <release version="2.2.1262" date="2021-01-19"/>

--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -69,9 +69,9 @@
                 {
                     "type": "extra-data",
                     "filename": "Minecraft.tar.gz",
-                    "url": "https://launcher.mojang.com/download/linux/x86_64/minecraft-launcher_2.2.1867.tar.gz",
-                    "sha256": "5e19e3459015fb28bc54df588b6613320281d953bc2f394a28a95465637eeabe",
-                    "size": 76767905,
+                    "url": "https://launcher.mojang.com/download/linux/x86_64/minecraft-launcher_921.tar.gz",
+                    "sha256": "e84cadeb55db50d673bb97d3ad1c9ad52f4e5999ed25fdcf3859cec43b5a449e",
+                    "size": 1323509,
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://launchermeta.mojang.com/v1/products/launcher/6f083b80d5e6fabbc4236f81d0d8f8a350c665a9/linux.json",

--- a/minecraft
+++ b/minecraft
@@ -1,13 +1,3 @@
 #!/bin/sh
 
-# Move minecraft profile if detected at old location
-if [ -d $XDG_DATA_HOME/../.minecraft ]; then
-    if [ ! -f $XDG_DATA_HOME/minecraft/.migrated ]; then
-        echo "Migrating to XDG dirs"
-        mkdir -p $XDG_DATA_HOME/minecraft
-        cp -frl $XDG_DATA_HOME/../.minecraft/* $XDG_DATA_HOME/minecraft/
-        touch $XDG_DATA_HOME/minecraft/.migrated
-    fi
-fi
-
-exec /app/extra/minecraft-launcher/minecraft-launcher $@ --workDir=$XDG_DATA_HOME/minecraft
+exec /app/extra/minecraft-launcher/minecraft-launcher $@


### PR DESCRIPTION
Work in progress, do not merge yet.

Crashes because of a broken _workDir_ switch in recent Launcher versions:
```
...
[Info: 2021-03-06 19:18:49.458277730: Common.cpp(32)] Native Launcher Version: 887
[Info: 2021-03-06 19:18:49.458314603: Common.cpp(33)] Operating System: Linux
[Info: 2021-03-06 19:18:49.458378193: Common.cpp(34)] Application Data directory: //.../.minecraft
[Info: 2021-03-06 19:18:49.458454110: Common.cpp(35)] Executable Path: /.../minecraft-launcher
[Info: 2021-03-06 19:18:49.458496661: Common.cpp(36)] App Directory dir: .../minecraft-launcher
[Info: 2021-03-06 19:18:49.458560184: Common.cpp(37)] Game data directory: .../minecraft
[Info: 2021-03-06 19:18:49.458622093: Common.cpp(38)] Launcher dir: .../minecraft/launcher
[Info: 2021-03-06 19:18:49.458671362: Common.cpp(39)] Java dir: .../minecraft/runtime/jre-x64
[Info: 2021-03-06 19:18:49.458710336: Common.cpp(40)] TmpDir dir: .../MinecraftLauncher
[Info: 2021-03-06 19:18:49.458746322: Common.cpp(41)] x64: true
...
[Error: 2021-03-06 19:18:50.285884930: Settings.cpp(33)] Failed to determine configuration file size: No such file or directory
[Error: 2021-03-06 19:18:50.286893905: mainLinux.cpp(191)] Couldn't determine absolute path for
...
[Info: 2021-03-06 19:18:49.867261146: ProductManager.cpp(212)] Product library dir set to /home/asciiwolf/.var/app/com.mojang.Minecraft/data/minecraft/products
[Info: 2021-03-06 19:18:49.867384733: AccountData.cpp(309)] Parsing content from file: .../minecraft/launcher_accounts.json
[Info: 2021-03-06 19:18:49.867531695: SkinManager.cpp(251)] Failed to read skins file: .../minecraft/launcher_skins.json ErrNo such file or directory
...
[0306/202251.819370:WARNING:gpu_process_host.cc(1262)] The GPU process has crashed 9 time(s)
[0306/202251.819413:FATAL:gpu_data_manager_impl_private.cc(445)] GPU process isn't usable. Goodbye.
[Info: 2021-03-06 19:22:51.815507970: NetQueue.cpp(154)] NetQueue: Setting up.
[Info: 2021-03-06 19:22:51.815734326: mainLinux.cpp(160)] Running launcher bootstrap (version 887)
[Error: 2021-03-06 19:22:51.860639778: Settings.cpp(33)] Failed to determine configuration file size: No such file or directory
[Error: 2021-03-06 19:22:51.862623320: mainLinux.cpp(191)] Couldn't determine absolute path for
```

(Unimportant log parts omitted.)

See this ticket: https://bugs.mojang.com/browse/MCL-17614

https://github.com/flathub/com.mojang.Minecraft/pull/78#issuecomment-803659607

Also, after this issue is resolved, x-data-checker should be fixed as well as part of this PR (see #76).