### PR TITLE
Remove Electron base app

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -5,8 +5,6 @@
     "sdk": "org.freedesktop.Sdk",
     "command": "minecraft",
     "separate-locales": false,
-    "base": "io.atom.electron.BaseApp",
-    "base-version": "20.08",
     "tags": [
         "proprietary"
     ],


### PR DESCRIPTION
It does not seem to be used anymore.