### PR TITLE
 Experimental native Wayland Support 

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -135,8 +135,8 @@
             "sources": [
               {
                 "type": "archive",
-                "url": "https://gitlab.gnome.org/jadahl/libdecoration/-/archive/master/libdecoration-master.tar.gz",
-                "sha256": "401efaed907d26f2775b05e8fea828aa3bc8f675bb7cc828b211ad77432ee16d"
+                "url": "https://gitlab.gnome.org/jadahl/libdecor/-/archive/0.1.0/libdecor-0.1.0.tar.gz",
+                "sha256": "1d5758cb49dcb9ceaa979ad14ceb6cdf39282af5ce12ebe6073dd193d6b2fb5e"
               }
             ]
           },

--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -111,6 +111,62 @@
                     "path": "com.mojang.Minecraft.appdata.xml"
                 }
             ]
+        },
+        
+        {
+            "name": "extra-cmake-modules",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+              "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+              {
+                "type": "archive",
+                "url": "https://download.kde.org/stable/frameworks/5.74/extra-cmake-modules-5.74.0.tar.xz",
+                "sha256": "71406067bcd99ac106e0e3bfbb073653b18fd6d01039c0298d9767680977364f"
+              }
+            ]
+          },
+          {
+            "name": "libdecor",
+            "buildsystem": "meson",
+            "builddir": true,
+            "sources": [
+              {
+                "type": "archive",
+                "url": "https://gitlab.gnome.org/jadahl/libdecoration/-/archive/master/libdecoration-master.tar.gz",
+                "sha256": "401efaed907d26f2775b05e8fea828aa3bc8f675bb7cc828b211ad77432ee16d"
+              }
+            ]
+          },
+        {
+            "name": "glfw",
+            "buildsystem": "cmake",
+            "config-opts": [
+                "-DCMAKE_INSTALL_LIBDIR=lib",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DGLFW_USE_WAYLAND=ON",
+                "-DGLFW_USE_LIBDECOR=ON"
+             ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/glfw/glfw/archive/6876cf8d7e0e70dc3e4d7b0224d08312c9f78099.tar.gz",
+                    "sha256": "70dd8d43efc3b7e5d71e687cb94989f9124d8457b834b221ff9e41c5c8feea9f"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "patches/0001-libdecoration-support.patch",
+                        "patches/0002-set-O_NONBLOCK-on-repeat-timerfd.patch",
+                        "patches/0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch",
+                        "patches/0004-fix-broken-opengl-screenshots-on-mutter.patch"
+                    ]               
+                }
+            ]
         }
+
+
     ]
 }

--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -14,7 +14,9 @@
         "--share=ipc",
         "--device=dri",
         "--socket=pulseaudio",
-        "--share=network"
+        "--share=network",
+        "--filesystem=~/.local/share/flatpak/app/com.mojang.Minecraft:ro",
+        "--filesystem=/var/lib/flatpak/app/com.mojang.Minecraft:ro"
         ],
     "modules": [
         {

--- a/patches/0001-libdecoration-support.patch
+++ b/patches/0001-libdecoration-support.patch
@@ -1,0 +1,930 @@
+From 6fb43e003d81f6adbdd75a302bd87763f185bb2c Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sun, 12 Apr 2020 14:21:03 +0100
+Subject: [PATCH 1/4] libdecoration support
+
+Applying PR https://github.com/glfw/glfw/pull/1693
+---
+ CMakeLists.txt    |  29 +++++
+ src/window.c      |   2 +-
+ src/wl_init.c     |  63 ++++++++++-
+ src/wl_platform.h |  23 +++-
+ src/wl_window.c   | 270 +++++++++++++++++++++++++++++++++++++---------
+ 5 files changed, 331 insertions(+), 56 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 59ab473c..71917d1e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,6 +40,8 @@ cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
+                        "UNIX;NOT APPLE" OFF)
+ cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
+                        "MSVC" OFF)
++cmake_dependent_option(GLFW_USE_LIBDECOR "use libdecor for client-side window decorations" ON
++                       "GLFW_USE_WAYLAND" OFF)
+ 
+ if (BUILD_SHARED_LIBS AND UNIX)
+     # On Unix-like systems, shared libraries can use the soname system.
+@@ -66,6 +68,25 @@ if (GLFW_BUILD_DOCS)
+     find_package(Doxygen)
+ endif()
+ 
++if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
++    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} \
++        -fsanitize=address \
++        -fsanitize=bool \
++        -fsanitize=bounds \
++        -fsanitize=enum \
++        -fsanitize=float-cast-overflow \
++        -fsanitize=float-divide-by-zero \
++        -fsanitize=nonnull-attribute \
++        -fsanitize=returns-nonnull-attribute \
++        -fsanitize=signed-integer-overflow \
++        -fsanitize=undefined \
++        -fsanitize=vla-bound \
++        -fno-sanitize=alignment \
++        -fsanitize=leak \
++        -fsanitize=object-size \
++    ")
++endif()
++
+ #--------------------------------------------------------------------
+ # Set compiler specific flags
+ #--------------------------------------------------------------------
+@@ -206,6 +227,14 @@ if (_GLFW_WAYLAND)
+     list(APPEND glfw_INCLUDE_DIRS "${Wayland_INCLUDE_DIRS}")
+     list(APPEND glfw_LIBRARIES "${Wayland_LINK_LIBRARIES}")
+ 
++    if (GLFW_USE_LIBDECOR)
++        pkg_check_modules(libdecor REQUIRED libdecor-0.1)
++        list(APPEND glfw_PKG_DEPS "libdecor-0.1")
++        list(APPEND glfw_INCLUDE_DIRS "${libdecor_INCLUDE_DIRS}")
++        list(APPEND glfw_LIBRARIES "${libdecor_LINK_LIBRARIES}")
++        add_definitions(-DWITH_DECORATION)
++    endif()
++
+     include(CheckIncludeFiles)
+     include(CheckFunctionExists)
+     check_include_files(xkbcommon/xkbcommon-compose.h HAVE_XKBCOMMON_COMPOSE_H)
+diff --git a/src/window.c b/src/window.c
+index 518b27fd..688971f3 100644
+--- a/src/window.c
++++ b/src/window.c
+@@ -279,7 +279,7 @@ void glfwDefaultWindowHints(void)
+     _glfw.hints.framebuffer.redBits      = 8;
+     _glfw.hints.framebuffer.greenBits    = 8;
+     _glfw.hints.framebuffer.blueBits     = 8;
+-    _glfw.hints.framebuffer.alphaBits    = 8;
++    _glfw.hints.framebuffer.alphaBits    = 0;
+     _glfw.hints.framebuffer.depthBits    = 24;
+     _glfw.hints.framebuffer.stencilBits  = 8;
+     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;
+diff --git a/src/wl_init.c b/src/wl_init.c
+index 1ba497b7..b6cdb39d 100644
+--- a/src/wl_init.c
++++ b/src/wl_init.c
+@@ -44,11 +44,14 @@
+ #include <wayland-client.h>
+ 
+ 
++const char *proxy_tag = "glfw-proxy";
++
+ static inline int min(int n1, int n2)
+ {
+     return n1 < n2 ? n1 : n2;
+ }
+ 
++#ifndef WITH_DECORATION
+ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+                                                     int* which)
+ {
+@@ -82,6 +85,20 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+     }
+     return window;
+ }
++#endif
++
++#ifdef WITH_DECORATION
++void decoration_error(struct libdecor *context,
++                      enum libdecor_error error,
++                      const char *message)
++{
++    _glfwInputError(GLFW_PLATFORM_ERROR, "Wayland: Caught error (%d): %s\n", error, message);
++}
++
++static struct libdecor_interface decoration_interface = {
++    decoration_error,
++};
++#endif
+ 
+ static void pointerHandleEnter(void* data,
+                                struct wl_pointer* pointer,
+@@ -94,8 +111,16 @@ static void pointerHandleEnter(void* data,
+     if (!surface)
+         return;
+ 
+-    int focus = 0;
++    if (wl_proxy_get_tag((struct wl_proxy *) surface) != &proxy_tag)
++        return;
++
+     _GLFWwindow* window = wl_surface_get_user_data(surface);
++
++#ifdef WITH_DECORATION
++    if (surface != window->wl.surface)
++        return;
++#else
++    int focus = 0;
+     if (!window)
+     {
+         window = findWindowFromDecorationSurface(surface, &focus);
+@@ -104,6 +129,8 @@ static void pointerHandleEnter(void* data,
+     }
+ 
+     window->wl.decorations.focus = focus;
++#endif
++
+     _glfw.wl.serial = serial;
+     _glfw.wl.pointerFocus = window;
+ 
+@@ -191,9 +218,16 @@ static void pointerHandleMotion(void* data,
+ 
+     if (window->cursorMode == GLFW_CURSOR_DISABLED)
+         return;
++
+     x = wl_fixed_to_double(sx);
+     y = wl_fixed_to_double(sy);
+ 
++#ifdef WITH_DECORATION
++    window->wl.cursorPosX = x;
++    window->wl.cursorPosY = y;
++    _glfwInputCursorPos(window, x, y);
++    _glfw.wl.cursorPreviousName = NULL;
++#else
+     switch (window->wl.decorations.focus)
+     {
+         case mainWindow:
+@@ -231,6 +265,7 @@ static void pointerHandleMotion(void* data,
+         default:
+             assert(0);
+     }
++#endif
+     if (_glfw.wl.cursorPreviousName != cursorName)
+         setCursor(window, cursorName);
+ }
+@@ -244,10 +279,11 @@ static void pointerHandleButton(void* data,
+ {
+     _GLFWwindow* window = _glfw.wl.pointerFocus;
+     int glfwButton;
+-    uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+ 
+     if (!window)
+         return;
++#ifndef WITH_DECORATION
++    uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+     if (button == BTN_LEFT)
+     {
+         switch (window->wl.decorations.focus)
+@@ -306,6 +342,7 @@ static void pointerHandleButton(void* data,
+     // Don’t pass the button to the user if it was related to a decoration.
+     if (window->wl.decorations.focus != mainWindow)
+         return;
++#endif
+ 
+     _glfw.wl.serial = serial;
+ 
+@@ -468,13 +505,21 @@ static void keyboardHandleEnter(void* data,
+     if (!surface)
+         return;
+ 
++    if (wl_proxy_get_tag((struct wl_proxy *) surface) != &proxy_tag)
++        return;
++
+     _GLFWwindow* window = wl_surface_get_user_data(surface);
++#ifdef WITH_DECORATION
++    if (surface != window->wl.surface)
++        return;
++#else
+     if (!window)
+     {
+         window = findWindowFromDecorationSurface(surface, NULL);
+         if (!window)
+             return;
+     }
++#endif
+ 
+     _glfw.wl.serial = serial;
+     _glfw.wl.keyboardFocus = window;
+@@ -769,6 +814,7 @@ static const struct wl_data_device_listener dataDeviceListener = {
+     dataDeviceHandleSelection,
+ };
+ 
++#ifndef WITH_DECORATION
+ static void wmBaseHandlePing(void* data,
+                              struct xdg_wm_base* wmBase,
+                              uint32_t serial)
+@@ -779,6 +825,7 @@ static void wmBaseHandlePing(void* data,
+ static const struct xdg_wm_base_listener wmBaseListener = {
+     wmBaseHandlePing
+ };
++#endif
+ 
+ static void registryHandleGlobal(void* data,
+                                  struct wl_registry* registry,
+@@ -827,6 +874,7 @@ static void registryHandleGlobal(void* data,
+                                  &wl_data_device_manager_interface, 1);
+         }
+     }
++#ifndef WITH_DECORATION
+     else if (strcmp(interface, "xdg_wm_base") == 0)
+     {
+         _glfw.wl.wmBase =
+@@ -845,6 +893,7 @@ static void registryHandleGlobal(void* data,
+         _glfw.wl.viewporter =
+             wl_registry_bind(registry, name, &wp_viewporter_interface, 1);
+     }
++#endif
+     else if (strcmp(interface, "zwp_relative_pointer_manager_v1") == 0)
+     {
+         _glfw.wl.relativePointerManager =
+@@ -1152,12 +1201,14 @@ int _glfwPlatformInit(void)
+     if (_glfw.wl.seatVersion >= 4)
+         _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+ 
++#ifndef WITH_DECORATION
+     if (!_glfw.wl.wmBase)
+     {
+         _glfwInputError(GLFW_PLATFORM_ERROR,
+                         "Wayland: Failed to find xdg-shell in your compositor");
+         return GLFW_FALSE;
+     }
++#endif
+ 
+     if (_glfw.wl.pointer && _glfw.wl.shm)
+     {
+@@ -1203,6 +1254,10 @@ int _glfwPlatformInit(void)
+         _glfw.wl.clipboardSize = 4096;
+     }
+ 
++#ifdef WITH_DECORATION
++    _glfw.wl.csd_context = libdecor_new(_glfw.wl.display, &decoration_interface);
++#endif
++
+     return GLFW_TRUE;
+ }
+ 
+@@ -1249,12 +1304,16 @@ void _glfwPlatformTerminate(void)
+         wl_compositor_destroy(_glfw.wl.compositor);
+     if (_glfw.wl.shm)
+         wl_shm_destroy(_glfw.wl.shm);
++#ifdef WITH_DECORATION
++    libdecor_unref(_glfw.wl.csd_context);
++#else
+     if (_glfw.wl.viewporter)
+         wp_viewporter_destroy(_glfw.wl.viewporter);
+     if (_glfw.wl.decorationManager)
+         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
+     if (_glfw.wl.wmBase)
+         xdg_wm_base_destroy(_glfw.wl.wmBase);
++#endif
+     if (_glfw.wl.dataSource)
+         wl_data_source_destroy(_glfw.wl.dataSource);
+     if (_glfw.wl.dataDevice)
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index 966155fd..b6b3392e 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -54,13 +54,18 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
+ #endif
+ #include "xkb_unicode.h"
+ 
+-#include "wayland-xdg-shell-client-protocol.h"
+-#include "wayland-xdg-decoration-client-protocol.h"
+-#include "wayland-viewporter-client-protocol.h"
+ #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
+ #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
+ #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
+ 
++#ifdef WITH_DECORATION
++#include <libdecor.h>
++#else
++#include "wayland-xdg-shell-client-protocol.h"
++#include "wayland-xdg-decoration-client-protocol.h"
++#include "wayland-viewporter-client-protocol.h"
++#endif
++
+ #define _glfw_dlopen(name) dlopen(name, RTLD_LAZY | RTLD_LOCAL)
+ #define _glfw_dlclose(handle) dlclose(handle)
+ #define _glfw_dlsym(handle, name) dlsym(handle, name)
+@@ -146,6 +151,7 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
+ #define _GLFW_DECORATION_VERTICAL (_GLFW_DECORATION_TOP + _GLFW_DECORATION_WIDTH)
+ #define _GLFW_DECORATION_HORIZONTAL (2 * _GLFW_DECORATION_WIDTH)
+ 
++#ifndef WITH_DECORATION
+ typedef enum _GLFWdecorationSideWayland
+ {
+     mainWindow,
+@@ -163,6 +169,7 @@ typedef struct _GLFWdecorationWayland
+     struct wp_viewport*         viewport;
+ 
+ } _GLFWdecorationWayland;
++#endif
+ 
+ // Wayland-specific per-window data
+ //
+@@ -177,11 +184,13 @@ typedef struct _GLFWwindowWayland
+     struct wl_egl_window*       native;
+     struct wl_callback*         callback;
+ 
++#ifndef WITH_DECORATION
+     struct {
+         struct xdg_surface*     surface;
+         struct xdg_toplevel*    toplevel;
+         struct zxdg_toplevel_decoration_v1* decoration;
+     } xdg;
++#endif
+ 
+     _GLFWcursor*                currentCursor;
+     double                      cursorPosX, cursorPosY;
+@@ -204,12 +213,16 @@ typedef struct _GLFWwindowWayland
+ 
+     GLFWbool                    wasFullscreen;
+ 
++#ifndef WITH_DECORATION
+     struct {
+         GLFWbool                           serverSide;
+         struct wl_buffer*                  buffer;
+         _GLFWdecorationWayland             top, left, right, bottom;
+         int                                focus;
+     } decorations;
++#else
++    struct libdecor_frame                   *decoration_frame;
++#endif
+ 
+ } _GLFWwindowWayland;
+ 
+@@ -229,9 +242,13 @@ typedef struct _GLFWlibraryWayland
+     struct wl_data_device*      dataDevice;
+     struct wl_data_offer*       dataOffer;
+     struct wl_data_source*      dataSource;
++#ifdef WITH_DECORATION
++    struct libdecor             *csd_context;
++#else
+     struct xdg_wm_base*         wmBase;
+     struct zxdg_decoration_manager_v1*      decorationManager;
+     struct wp_viewporter*       viewporter;
++#endif
+     struct zwp_relative_pointer_manager_v1* relativePointerManager;
+     struct zwp_pointer_constraints_v1*      pointerConstraints;
+     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 939f9c19..47cc1437 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -40,6 +40,12 @@
+ #include <sys/timerfd.h>
+ #include <poll.h>
+ 
++#ifdef WITH_DECORATION
++#include <libdecor.h>
++#endif
++
++
++extern const char *proxy_tag;
+ 
+ static int createTmpfileCloexec(char* tmpname)
+ {
+@@ -182,6 +188,61 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
+     return buffer;
+ }
+ 
++#ifdef WITH_DECORATION
++static void resizeWindow(_GLFWwindow* window);
++void frame_configure(struct libdecor_frame *frame, struct libdecor_configuration *configuration, void *user_data)
++{
++    _GLFWwindow* window = user_data;
++
++    int width, height;
++    if (!libdecor_configuration_get_content_size(configuration, frame, &width, &height)) {
++        width = window->wl.width;
++        height = window->wl.height;
++    }
++
++    window->wl.width = width;
++    window->wl.height = height;
++    resizeWindow(window);
++
++    _glfwInputWindowSize(window, width, height);
++    _glfwPlatformSetWindowSize(window, width, height);
++    _glfwInputWindowDamage(window);
++
++    struct libdecor_state *state = libdecor_state_new(width, height);
++    libdecor_frame_commit(frame, state, configuration);
++    libdecor_state_free(state);
++}
++
++void frame_close(struct libdecor_frame *frame, void *user_data)
++{
++    _glfwInputWindowCloseRequest(user_data);
++}
++
++void frame_commit(struct libdecor_frame *frame, void *user_data)
++{
++    _GLFWwindow* window = user_data;
++
++    _glfwInputWindowDamage(window);
++}
++
++static struct libdecor_frame_interface frame_interface = {
++	frame_configure,
++	frame_close,
++	frame_commit,
++};
++#endif
++
++#ifdef WITH_DECORATION
++static void createDecorations(_GLFWwindow* window)
++{
++    // TODO: enable decoration
++}
++
++static void destroyDecorations(_GLFWwindow* window)
++{
++    // TODO: disable decoration
++}
++#else
+ static void createDecoration(_GLFWdecorationWayland* decoration,
+                              struct wl_surface* parent,
+                              struct wl_buffer* buffer, GLFWbool opaque,
+@@ -264,22 +325,23 @@ static void destroyDecorations(_GLFWwindow* window)
+     destroyDecoration(&window->wl.decorations.right);
+     destroyDecoration(&window->wl.decorations.bottom);
+ }
++#endif
+ 
++#ifndef WITH_DECORATION
+ static void xdgDecorationHandleConfigure(void* data,
+                                          struct zxdg_toplevel_decoration_v1* decoration,
+                                          uint32_t mode)
+ {
+     _GLFWwindow* window = data;
+ 
+-    window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+-
+-    if (!window->wl.decorations.serverSide)
++    if (!(window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)))
+         createDecorations(window);
+ }
+ 
+ static const struct zxdg_toplevel_decoration_v1_listener xdgDecorationListener = {
+     xdgDecorationHandleConfigure,
+ };
++#endif
+ 
+ // Makes the surface considered as XRGB instead of ARGB.
+ static void setOpaqueRegion(_GLFWwindow* window)
+@@ -292,7 +354,6 @@ static void setOpaqueRegion(_GLFWwindow* window)
+ 
+     wl_region_add(region, 0, 0, window->wl.width, window->wl.height);
+     wl_surface_set_opaque_region(window->wl.surface, region);
+-    wl_surface_commit(window->wl.surface);
+     wl_region_destroy(region);
+ }
+ 
+@@ -308,6 +369,7 @@ static void resizeWindow(_GLFWwindow* window)
+     _glfwInputFramebufferSize(window, scaledWidth, scaledHeight);
+     _glfwInputWindowContentScale(window, scale, scale);
+ 
++#ifndef WITH_DECORATION
+     if (!window->wl.decorations.top.surface)
+         return;
+ 
+@@ -334,6 +396,7 @@ static void resizeWindow(_GLFWwindow* window)
+     wp_viewport_set_destination(window->wl.decorations.bottom.viewport,
+                                 window->wl.width + _GLFW_DECORATION_HORIZONTAL, _GLFW_DECORATION_WIDTH);
+     wl_surface_commit(window->wl.decorations.bottom.surface);
++#endif
+ }
+ 
+ static void checkScaleChange(_GLFWwindow* window)
+@@ -367,6 +430,9 @@ static void surfaceHandleEnter(void *data,
+                                struct wl_surface *surface,
+                                struct wl_output *output)
+ {
++    if (wl_proxy_get_tag((struct wl_proxy *) output) != &proxy_tag)
++        return;
++
+     _GLFWwindow* window = data;
+     _GLFWmonitor* monitor = wl_output_get_user_data(output);
+ 
+@@ -387,6 +453,9 @@ static void surfaceHandleLeave(void *data,
+                                struct wl_surface *surface,
+                                struct wl_output *output)
+ {
++    if (wl_proxy_get_tag((struct wl_proxy *) output) != &proxy_tag)
++        return;
++
+     _GLFWwindow* window = data;
+     _GLFWmonitor* monitor = wl_output_get_user_data(output);
+     GLFWbool found;
+@@ -427,8 +496,7 @@ static void setIdleInhibitor(_GLFWwindow* window, GLFWbool enable)
+     }
+ }
+ 
+-static GLFWbool createSurface(_GLFWwindow* window,
+-                              const _GLFWwndconfig* wndconfig)
++static GLFWbool createSurface(_GLFWwindow* window)
+ {
+     window->wl.surface = wl_compositor_create_surface(_glfw.wl.compositor);
+     if (!window->wl.surface)
+@@ -439,37 +507,60 @@ static GLFWbool createSurface(_GLFWwindow* window,
+                             window);
+ 
+     wl_surface_set_user_data(window->wl.surface, window);
++    wl_proxy_set_tag((struct wl_proxy *) window->wl.surface, &proxy_tag);
++
++    wl_display_roundtrip(_glfw.wl.display);
++    wl_display_roundtrip(_glfw.wl.display);
+ 
+     window->wl.native = wl_egl_window_create(window->wl.surface,
+-                                             wndconfig->width,
+-                                             wndconfig->height);
++                                             window->wl.width,
++                                             window->wl.height);
+     if (!window->wl.native)
+         return GLFW_FALSE;
+ 
+-    window->wl.width = wndconfig->width;
+-    window->wl.height = wndconfig->height;
+-    window->wl.scale = 1;
+-
+     if (!window->wl.transparent)
+         setOpaqueRegion(window);
+ 
+     return GLFW_TRUE;
+ }
+ 
++#ifdef WITH_DECORATION
++static GLFWbool createSurfaceDecoration(_GLFWwindow* window)
++{
++    window->wl.decoration_frame = libdecor_decorate(_glfw.wl.csd_context,
++                                                    window->wl.surface,
++                                                    &frame_interface,
++                                                    window);
++    libdecor_frame_map(window->wl.decoration_frame);
++
++    window->wl.scale = 1;
++
++    return GLFW_TRUE;
++}
++#endif
++
+ static void setFullscreen(_GLFWwindow* window, _GLFWmonitor* monitor,
+                           int refreshRate)
+ {
++#ifdef WITH_DECORATION
++    libdecor_frame_set_fullscreen(window->wl.decoration_frame, monitor->wl.output);
++#else
+     if (window->wl.xdg.toplevel)
+     {
+         xdg_toplevel_set_fullscreen(
+             window->wl.xdg.toplevel,
+             monitor->wl.output);
+     }
++#endif
+     setIdleInhibitor(window, GLFW_TRUE);
++#ifndef WITH_DECORATION
+     if (!window->wl.decorations.serverSide)
+         destroyDecorations(window);
++#endif
+ }
+ 
++#ifndef WITH_DECORATION
++
+ static void xdgToplevelHandleConfigure(void* data,
+                                        struct xdg_toplevel* toplevel,
+                                        int32_t width,
+@@ -639,6 +730,7 @@ static GLFWbool createXdgSurface(_GLFWwindow* window)
+ 
+     return GLFW_TRUE;
+ }
++#endif
+ 
+ static void setCursorImage(_GLFWwindow* window,
+                            _GLFWcursorWayland* cursorWayland)
+@@ -690,8 +782,12 @@ static void incrementCursorImage(_GLFWwindow* window)
+ {
+     _GLFWcursor* cursor;
+ 
+-    if (!window || window->wl.decorations.focus != mainWindow)
++    if (!window) return;
++
++#ifndef WITH_DECORATION
++    if (window->wl.decorations.focus != mainWindow)
+         return;
++#endif
+ 
+     cursor = window->wl.currentCursor;
+     if (cursor && cursor->wl.cursor)
+@@ -788,7 +884,17 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+ {
+     window->wl.transparent = fbconfig->transparent;
+ 
+-    if (!createSurface(window, wndconfig))
++    window->wl.visible = wndconfig->visible;
++    window->wl.width = wndconfig->width;
++    window->wl.height = wndconfig->height;
++
++    // TODO: enable visibility support
++    window->wl.visible = GLFW_TRUE;
++
++    // unsupported on Wayland by design
++    window->focusOnShow = GLFW_FALSE;
++
++    if (!createSurface(window))
+         return GLFW_FALSE;
+ 
+     if (ctxconfig->client != GLFW_NO_API)
+@@ -810,9 +916,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+         }
+     }
+ 
+-    if (wndconfig->title)
+-        window->wl.title = _glfw_strdup(wndconfig->title);
+-
++#ifndef WITH_DECORATION
+     if (wndconfig->visible)
+     {
+         if (!createXdgSurface(window))
+@@ -826,6 +930,19 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+         window->wl.xdg.toplevel = NULL;
+         window->wl.visible = GLFW_FALSE;
+     }
++#else
++    if (!createSurfaceDecoration(window))
++        return GLFW_FALSE;
++#endif
++
++    window->wl.scale = 1;
++
++    _glfwPlatformSetWindowTitle(window, wndconfig->title);
++
++    _glfwPlatformSetWindowResizable(window, wndconfig->resizable);
++
++    if (window->monitor)
++        setFullscreen(window, window->monitor, window->videoMode.refreshRate);
+ 
+     window->wl.currentCursor = NULL;
+ 
+@@ -833,6 +950,8 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+     window->wl.monitorsCount = 0;
+     window->wl.monitorsSize = 1;
+ 
++    wl_display_roundtrip(_glfw.wl.display);
++
+     return GLFW_TRUE;
+ }
+ 
+@@ -856,20 +975,25 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
+         window->context.destroy(window);
+ 
+     destroyDecorations(window);
++#ifdef WITH_DECORATION
++    libdecor_frame_unref(window->wl.decoration_frame);
++#else
+     if (window->wl.xdg.decoration)
+         zxdg_toplevel_decoration_v1_destroy(window->wl.xdg.decoration);
+-
+     if (window->wl.decorations.buffer)
+         wl_buffer_destroy(window->wl.decorations.buffer);
++#endif
+ 
+     if (window->wl.native)
+         wl_egl_window_destroy(window->wl.native);
+ 
++#ifndef WITH_DECORATION
+     if (window->wl.xdg.toplevel)
+         xdg_toplevel_destroy(window->wl.xdg.toplevel);
+ 
+     if (window->wl.xdg.surface)
+         xdg_surface_destroy(window->wl.xdg.surface);
++#endif
+ 
+     if (window->wl.surface)
+         wl_surface_destroy(window->wl.surface);
+@@ -883,8 +1007,15 @@ void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title)
+     if (window->wl.title)
+         free(window->wl.title);
+     window->wl.title = _glfw_strdup(title);
+-    if (window->wl.xdg.toplevel)
+-        xdg_toplevel_set_title(window->wl.xdg.toplevel, title);
++
++#ifdef WITH_DECORATION
++    if (window->wl.decoration_frame) {
++        libdecor_frame_set_title(window->wl.decoration_frame, window->wl.title);
++        libdecor_frame_set_app_id(window->wl.decoration_frame, window->wl.title);
++    }
++#else
++    xdg_toplevel_set_title(window->wl.xdg.toplevel, title);
++#endif
+ }
+ 
+ void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
+@@ -930,16 +1061,23 @@ void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
+                                       int minwidth, int minheight,
+                                       int maxwidth, int maxheight)
+ {
++    if (minwidth == GLFW_DONT_CARE || minheight == GLFW_DONT_CARE)
++        minwidth = minheight = 0;
++    if (maxwidth == GLFW_DONT_CARE || maxheight == GLFW_DONT_CARE)
++        maxwidth = maxheight = 0;
++#ifdef WITH_DECORATION
++    libdecor_frame_set_min_content_size(window->wl.decoration_frame,
++                                        minwidth, minheight);
++    libdecor_frame_set_max_content_size(window->wl.decoration_frame,
++                                        maxwidth, maxheight);
++#else
+     if (window->wl.xdg.toplevel)
+     {
+-        if (minwidth == GLFW_DONT_CARE || minheight == GLFW_DONT_CARE)
+-            minwidth = minheight = 0;
+-        if (maxwidth == GLFW_DONT_CARE || maxheight == GLFW_DONT_CARE)
+-            maxwidth = maxheight = 0;
+         xdg_toplevel_set_min_size(window->wl.xdg.toplevel, minwidth, minheight);
+         xdg_toplevel_set_max_size(window->wl.xdg.toplevel, maxwidth, maxheight);
+-        wl_surface_commit(window->wl.surface);
+     }
++#endif
++    wl_surface_commit(window->wl.surface);
+ }
+ 
+ void _glfwPlatformSetWindowAspectRatio(_GLFWwindow* window,
+@@ -965,6 +1103,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
+                                      int* left, int* top,
+                                      int* right, int* bottom)
+ {
++#ifndef WITH_DECORATION
+     if (window->decorated && !window->monitor && !window->wl.decorations.serverSide)
+     {
+         if (top)
+@@ -976,6 +1115,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
+         if (bottom)
+             *bottom = _GLFW_DECORATION_WIDTH;
+     }
++#endif
+ }
+ 
+ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
+@@ -989,31 +1129,37 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
+ 
+ void _glfwPlatformIconifyWindow(_GLFWwindow* window)
+ {
+-    if (window->wl.xdg.toplevel)
+-        xdg_toplevel_set_minimized(window->wl.xdg.toplevel);
++#ifdef WITH_DECORATION
++    libdecor_frame_set_minimized(window->wl.decoration_frame);
++#else
++    xdg_toplevel_set_minimized(window->wl.xdg.toplevel);
++#endif
+ }
+ 
+ void _glfwPlatformRestoreWindow(_GLFWwindow* window)
+ {
+-    if (window->wl.xdg.toplevel)
+-    {
+-        if (window->monitor)
+-            xdg_toplevel_unset_fullscreen(window->wl.xdg.toplevel);
+-        if (window->wl.maximized)
+-            xdg_toplevel_unset_maximized(window->wl.xdg.toplevel);
+-        // There is no way to unset minimized, or even to know if we are
+-        // minimized, so there is nothing to do in this case.
+-    }
++#ifdef WITH_DECORATION
++    libdecor_frame_unset_fullscreen(window->wl.decoration_frame);
++    libdecor_frame_unset_maximized(window->wl.decoration_frame);
++#else
++    if (window->monitor)
++        xdg_toplevel_unset_fullscreen(window->wl.xdg.toplevel);
++    if (window->wl.maximized)
++        xdg_toplevel_unset_maximized(window->wl.xdg.toplevel);
++    // There is no way to unset minimized, or even to know if we are
++    // minimized, so there is nothing to do in this case.
++#endif
+     _glfwInputWindowMonitor(window, NULL);
+     window->wl.maximized = GLFW_FALSE;
+ }
+ 
+ void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
+ {
+-    if (window->wl.xdg.toplevel)
+-    {
+-        xdg_toplevel_set_maximized(window->wl.xdg.toplevel);
+-    }
++#ifdef WITH_DECORATION
++    libdecor_frame_set_maximized(window->wl.decoration_frame);
++#else
++    xdg_toplevel_set_maximized(window->wl.xdg.toplevel);
++#endif
+     window->wl.maximized = GLFW_TRUE;
+ }
+ 
+@@ -1021,13 +1167,18 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
+ {
+     if (!window->wl.visible)
+     {
+-        createXdgSurface(window);
+         window->wl.visible = GLFW_TRUE;
++#ifndef WITH_DECORATION
++        createXdgSurface(window);
++#else
++        // TODO: enable visibility support
++#endif
+     }
+ }
+ 
+ void _glfwPlatformHideWindow(_GLFWwindow* window)
+ {
++#ifndef WITH_DECORATION
+     if (window->wl.xdg.toplevel)
+     {
+         xdg_toplevel_destroy(window->wl.xdg.toplevel);
+@@ -1035,6 +1186,9 @@ void _glfwPlatformHideWindow(_GLFWwindow* window)
+         window->wl.xdg.toplevel = NULL;
+         window->wl.xdg.surface = NULL;
+     }
++#else
++    // TODO: enable visibility support
++#endif
+     window->wl.visible = GLFW_FALSE;
+ }
+ 
+@@ -1063,11 +1217,14 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
+     }
+     else
+     {
+-        if (window->wl.xdg.toplevel)
+-            xdg_toplevel_unset_fullscreen(window->wl.xdg.toplevel);
++#ifdef WITH_DECORATION
++        libdecor_frame_unset_fullscreen(window->wl.decoration_frame);
++#else
++        xdg_toplevel_unset_fullscreen(window->wl.xdg.toplevel);
+         setIdleInhibitor(window, GLFW_FALSE);
+         if (!_glfw.wl.decorationManager)
+             createDecorations(window);
++#endif
+     }
+     _glfwInputWindowMonitor(window, monitor);
+ }
+@@ -1106,9 +1263,14 @@ int _glfwPlatformFramebufferTransparent(_GLFWwindow* window)
+ 
+ void _glfwPlatformSetWindowResizable(_GLFWwindow* window, GLFWbool enabled)
+ {
+-    // TODO
+-    _glfwInputError(GLFW_FEATURE_UNIMPLEMENTED,
+-                    "Wayland: Window attribute setting not implemented yet");
++#ifdef WITH_DECORATION
++    if (enabled)
++        libdecor_frame_set_capabilities(window->wl.decoration_frame,
++                                        LIBDECOR_ACTION_RESIZE);
++    else
++        libdecor_frame_unset_capabilities(window->wl.decoration_frame,
++                                        LIBDECOR_ACTION_RESIZE);
++#endif
+ }
+ 
+ void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
+@@ -1124,9 +1286,13 @@ void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
+ 
+ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
+ {
+-    // TODO
+-    _glfwInputError(GLFW_FEATURE_UNIMPLEMENTED,
+-                    "Wayland: Window attribute setting not implemented yet");
++#ifdef WITH_DECORATION
++    if (window->wl.maximized)
++        libdecor_frame_unset_maximized(window->wl.decoration_frame);
++
++    if (window->wl.wasFullscreen)
++        libdecor_frame_unset_fullscreen(window->wl.decoration_frame);
++#endif
+ }
+ 
+ void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow* window, GLFWbool enabled)
+@@ -1459,10 +1625,14 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
+ 
+     window->wl.currentCursor = cursor;
+ 
++    if (window != _glfw.wl.pointerFocus) return;
++
++#ifndef WITH_DECORATION
+     // If we're not in the correct window just save the cursor
+     // the next time the pointer enters the window the cursor will change
+-    if (window != _glfw.wl.pointerFocus || window->wl.decorations.focus != mainWindow)
++    if (window->wl.decorations.focus != mainWindow)
+         return;
++#endif
+ 
+     // Unlock possible pointer lock if no longer disabled.
+     if (window->cursorMode != GLFW_CURSOR_DISABLED && isPointerLocked(window))
+-- 
+2.32.0
+

--- a/patches/0001-libdecoration-support.patch
+++ b/patches/0001-libdecoration-support.patch
@@ -1,31 +1,86 @@
-From 6fb43e003d81f6adbdd75a302bd87763f185bb2c Mon Sep 17 00:00:00 2001
+From 55966a31213985d234981d357a2dd9da4d659764 Mon Sep 17 00:00:00 2001
 From: Christian Rauch <Rauch.Christian@gmx.de>
 Date: Sun, 12 Apr 2020 14:21:03 +0100
-Subject: [PATCH 1/4] libdecoration support
+Subject: [PATCH 1/8] wl: fix resize glitches
 
-Applying PR https://github.com/glfw/glfw/pull/1693
 ---
- CMakeLists.txt    |  29 +++++
- src/window.c      |   2 +-
- src/wl_init.c     |  63 ++++++++++-
- src/wl_platform.h |  23 +++-
- src/wl_window.c   | 270 +++++++++++++++++++++++++++++++++++++---------
- 5 files changed, 331 insertions(+), 56 deletions(-)
+ src/wl_window.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 939f9c1966..3899c858c1 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -292,7 +292,6 @@ static void setOpaqueRegion(_GLFWwindow* window)
+ 
+     wl_region_add(region, 0, 0, window->wl.width, window->wl.height);
+     wl_surface_set_opaque_region(window->wl.surface, region);
+-    wl_surface_commit(window->wl.surface);
+     wl_region_destroy(region);
+ }
+ 
+
+From af0f596bfa7654415a40dc87a3dfef9bed5b0fe8 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sat, 9 May 2020 21:06:23 +0100
+Subject: [PATCH 2/8] wl: initialise fullscreen
+
+---
+ src/wl_window.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 3899c858c1..46cd742c67 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -826,6 +826,9 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+         window->wl.visible = GLFW_FALSE;
+     }
+ 
++    if (window->monitor)
++        setFullscreen(window, window->monitor, window->videoMode.refreshRate);
++
+     window->wl.currentCursor = NULL;
+ 
+     window->wl.monitors = calloc(1, sizeof(_GLFWmonitor*));
+
+From d23cdad8bb183393252a38735171cb3e7b379e39 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Mon, 3 May 2021 23:46:21 +0100
+Subject: [PATCH 3/8] make windows opaque by default
+
+---
+ src/window.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/window.c b/src/window.c
+index 518b27fd5a..688971f368 100644
+--- a/src/window.c
++++ b/src/window.c
+@@ -279,7 +279,7 @@ void glfwDefaultWindowHints(void)
+     _glfw.hints.framebuffer.redBits      = 8;
+     _glfw.hints.framebuffer.greenBits    = 8;
+     _glfw.hints.framebuffer.blueBits     = 8;
+-    _glfw.hints.framebuffer.alphaBits    = 8;
++    _glfw.hints.framebuffer.alphaBits    = 0;
+     _glfw.hints.framebuffer.depthBits    = 24;
+     _glfw.hints.framebuffer.stencilBits  = 8;
+     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;
+
+From 5e9c31e434117f6208e10b3e2ffe636a39cb69df Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Fri, 19 Jun 2020 00:05:12 +0100
+Subject: [PATCH 4/8] cmake: enable AddressSanitizer in Debug builds
+
+---
+ CMakeLists.txt | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 59ab473c..71917d1e 100644
+index 59ab473c9e..fb9fab99ab 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -40,6 +40,8 @@ cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
-                        "UNIX;NOT APPLE" OFF)
- cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
-                        "MSVC" OFF)
-+cmake_dependent_option(GLFW_USE_LIBDECOR "use libdecor for client-side window decorations" ON
-+                       "GLFW_USE_WAYLAND" OFF)
- 
- if (BUILD_SHARED_LIBS AND UNIX)
-     # On Unix-like systems, shared libraries can use the soname system.
-@@ -66,6 +68,25 @@ if (GLFW_BUILD_DOCS)
+@@ -66,6 +66,25 @@ if (GLFW_BUILD_DOCS)
      find_package(Doxygen)
  endif()
  
@@ -51,13 +106,63 @@ index 59ab473c..71917d1e 100644
  #--------------------------------------------------------------------
  # Set compiler specific flags
  #--------------------------------------------------------------------
-@@ -206,6 +227,14 @@ if (_GLFW_WAYLAND)
+
+From 7bcb0e0d354d2e82671c1f3a32d261f8e50ed87d Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Fri, 16 Jul 2021 23:40:45 +0100
+Subject: [PATCH 5/8] CI: install libdecor from upstream
+
+---
+ .github/workflows/build.yml | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
+index d87ae8d1d6..71d5976e58 100644
+--- a/.github/workflows/build.yml
++++ b/.github/workflows/build.yml
+@@ -43,6 +43,12 @@ jobs:
+               run: |
+                   sudo apt update
+                   sudo apt install wayland-protocols libwayland-dev libxkbcommon-dev
++                  sudo apt install meson
++                  git clone --depth 1 https://gitlab.gnome.org/jadahl/libdecor.git --branch 0.1.0
++                  cd libdecor
++                  meson build --buildtype release -Ddemo=false -Ddbus=disabled
++                  ninja -C build
++                  sudo meson install -C build
+ 
+             - name: Configure static library
+               run: cmake -S . -B build-static -D GLFW_USE_WAYLAND=ON
+
+From ae0bde5733c481c8097f903b020c4ac0bfdedf96 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sun, 9 Feb 2020 14:01:58 +0000
+Subject: [PATCH 6/8] cmake: add 'libdecor' dependency
+
+---
+ CMakeLists.txt | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fb9fab99ab..2ff626ac75 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,6 +40,8 @@ cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
+                        "UNIX;NOT APPLE" OFF)
+ cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
+                        "MSVC" OFF)
++cmake_dependent_option(GLFW_USE_LIBDECOR "use libdecor for client-side window decorations" ON
++                       "GLFW_USE_WAYLAND" OFF)
+ 
+ if (BUILD_SHARED_LIBS AND UNIX)
+     # On Unix-like systems, shared libraries can use the soname system.
+@@ -225,6 +227,14 @@ if (_GLFW_WAYLAND)
      list(APPEND glfw_INCLUDE_DIRS "${Wayland_INCLUDE_DIRS}")
      list(APPEND glfw_LIBRARIES "${Wayland_LINK_LIBRARIES}")
  
 +    if (GLFW_USE_LIBDECOR)
-+        pkg_check_modules(libdecor REQUIRED libdecor-0.1)
-+        list(APPEND glfw_PKG_DEPS "libdecor-0.1")
++        pkg_check_modules(libdecor REQUIRED libdecor-0)
++        list(APPEND glfw_PKG_DEPS "libdecor-0")
 +        list(APPEND glfw_INCLUDE_DIRS "${libdecor_INCLUDE_DIRS}")
 +        list(APPEND glfw_LIBRARIES "${libdecor_LINK_LIBRARIES}")
 +        add_definitions(-DWITH_DECORATION)
@@ -66,21 +171,361 @@ index 59ab473c..71917d1e 100644
      include(CheckIncludeFiles)
      include(CheckFunctionExists)
      check_include_files(xkbcommon/xkbcommon-compose.h HAVE_XKBCOMMON_COMPOSE_H)
-diff --git a/src/window.c b/src/window.c
-index 518b27fd..688971f3 100644
---- a/src/window.c
-+++ b/src/window.c
-@@ -279,7 +279,7 @@ void glfwDefaultWindowHints(void)
-     _glfw.hints.framebuffer.redBits      = 8;
-     _glfw.hints.framebuffer.greenBits    = 8;
-     _glfw.hints.framebuffer.blueBits     = 8;
--    _glfw.hints.framebuffer.alphaBits    = 8;
-+    _glfw.hints.framebuffer.alphaBits    = 0;
-     _glfw.hints.framebuffer.depthBits    = 24;
-     _glfw.hints.framebuffer.stencilBits  = 8;
-     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;
+
+From 814a4c197a6f343b772328df68317a028a9e7e84 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sun, 9 Feb 2020 14:56:27 +0000
+Subject: [PATCH 7/8] wl: deactivate 'viewporter' decorations
+
+---
+ src/wl_init.c     | 13 +++++++++++
+ src/wl_platform.h | 10 +++++++++
+ src/wl_window.c   | 57 ++++++++++++++++++++++++++++++++++++++++++-----
+ 3 files changed, 74 insertions(+), 6 deletions(-)
+
 diff --git a/src/wl_init.c b/src/wl_init.c
-index 1ba497b7..b6cdb39d 100644
+index 1ba497b718..d49e44e77b 100644
+--- a/src/wl_init.c
++++ b/src/wl_init.c
+@@ -56,6 +56,7 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+     _GLFWwindow* window = _glfw.windowListHead;
+     if (!which)
+         which = &focus;
++#ifndef WITH_DECORATION
+     while (window)
+     {
+         if (surface == window->wl.decorations.top.surface)
+@@ -80,6 +81,7 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+         }
+         window = window->next;
+     }
++#endif
+     return window;
+ }
+ 
+@@ -103,7 +105,10 @@ static void pointerHandleEnter(void* data,
+             return;
+     }
+ 
++#ifndef WITH_DECORATION
+     window->wl.decorations.focus = focus;
++#endif
++
+     _glfw.wl.serial = serial;
+     _glfw.wl.pointerFocus = window;
+ 
+@@ -194,6 +199,7 @@ static void pointerHandleMotion(void* data,
+     x = wl_fixed_to_double(sx);
+     y = wl_fixed_to_double(sy);
+ 
++#ifndef WITH_DECORATION
+     switch (window->wl.decorations.focus)
+     {
+         case mainWindow:
+@@ -231,6 +237,7 @@ static void pointerHandleMotion(void* data,
+         default:
+             assert(0);
+     }
++#endif
+     if (_glfw.wl.cursorPreviousName != cursorName)
+         setCursor(window, cursorName);
+ }
+@@ -248,6 +255,7 @@ static void pointerHandleButton(void* data,
+ 
+     if (!window)
+         return;
++#ifndef WITH_DECORATION
+     if (button == BTN_LEFT)
+     {
+         switch (window->wl.decorations.focus)
+@@ -306,6 +314,7 @@ static void pointerHandleButton(void* data,
+     // Don’t pass the button to the user if it was related to a decoration.
+     if (window->wl.decorations.focus != mainWindow)
+         return;
++#endif
+ 
+     _glfw.wl.serial = serial;
+ 
+@@ -840,11 +849,13 @@ static void registryHandleGlobal(void* data,
+                              &zxdg_decoration_manager_v1_interface,
+                              1);
+     }
++#ifndef WITH_DECORATION
+     else if (strcmp(interface, "wp_viewporter") == 0)
+     {
+         _glfw.wl.viewporter =
+             wl_registry_bind(registry, name, &wp_viewporter_interface, 1);
+     }
++#endif
+     else if (strcmp(interface, "zwp_relative_pointer_manager_v1") == 0)
+     {
+         _glfw.wl.relativePointerManager =
+@@ -1249,8 +1260,10 @@ void _glfwPlatformTerminate(void)
+         wl_compositor_destroy(_glfw.wl.compositor);
+     if (_glfw.wl.shm)
+         wl_shm_destroy(_glfw.wl.shm);
++#ifndef WITH_DECORATION
+     if (_glfw.wl.viewporter)
+         wp_viewporter_destroy(_glfw.wl.viewporter);
++#endif
+     if (_glfw.wl.decorationManager)
+         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
+     if (_glfw.wl.wmBase)
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index 966155fdda..4591becbd0 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -56,7 +56,9 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
+ 
+ #include "wayland-xdg-shell-client-protocol.h"
+ #include "wayland-xdg-decoration-client-protocol.h"
++#ifndef WITH_DECORATION
+ #include "wayland-viewporter-client-protocol.h"
++#endif
+ #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
+ #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
+ #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
+@@ -146,6 +148,7 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
+ #define _GLFW_DECORATION_VERTICAL (_GLFW_DECORATION_TOP + _GLFW_DECORATION_WIDTH)
+ #define _GLFW_DECORATION_HORIZONTAL (2 * _GLFW_DECORATION_WIDTH)
+ 
++#ifndef WITH_DECORATION
+ typedef enum _GLFWdecorationSideWayland
+ {
+     mainWindow,
+@@ -163,6 +166,7 @@ typedef struct _GLFWdecorationWayland
+     struct wp_viewport*         viewport;
+ 
+ } _GLFWdecorationWayland;
++#endif
+ 
+ // Wayland-specific per-window data
+ //
+@@ -204,12 +208,16 @@ typedef struct _GLFWwindowWayland
+ 
+     GLFWbool                    wasFullscreen;
+ 
++#ifndef WITH_DECORATION
+     struct {
+         GLFWbool                           serverSide;
+         struct wl_buffer*                  buffer;
+         _GLFWdecorationWayland             top, left, right, bottom;
+         int                                focus;
+     } decorations;
++#else
++    GLFWbool                                ssd;
++#endif
+ 
+ } _GLFWwindowWayland;
+ 
+@@ -231,7 +239,9 @@ typedef struct _GLFWlibraryWayland
+     struct wl_data_source*      dataSource;
+     struct xdg_wm_base*         wmBase;
+     struct zxdg_decoration_manager_v1*      decorationManager;
++#ifndef WITH_DECORATION
+     struct wp_viewporter*       viewporter;
++#endif
+     struct zwp_relative_pointer_manager_v1* relativePointerManager;
+     struct zwp_pointer_constraints_v1*      pointerConstraints;
+     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 46cd742c67..9e10e8a3fd 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -40,6 +40,10 @@
+ #include <sys/timerfd.h>
+ #include <poll.h>
+ 
++#ifdef WITH_DECORATION
++#include <libdecoration.h>
++#endif
++
+ 
+ static int createTmpfileCloexec(char* tmpname)
+ {
+@@ -182,6 +186,7 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
+     return buffer;
+ }
+ 
++#ifndef WITH_DECORATION
+ static void createDecoration(_GLFWdecorationWayland* decoration,
+                              struct wl_surface* parent,
+                              struct wl_buffer* buffer, GLFWbool opaque,
+@@ -211,7 +216,14 @@ static void createDecoration(_GLFWdecorationWayland* decoration,
+     else
+         wl_surface_commit(decoration->surface);
+ }
++#endif
+ 
++#ifdef WITH_DECORATION
++static void createDecorations(_GLFWwindow* window)
++{
++    //
++}
++#else
+ static void createDecorations(_GLFWwindow* window)
+ {
+     unsigned char data[] = { 224, 224, 224, 255 };
+@@ -243,7 +255,9 @@ static void createDecorations(_GLFWwindow* window)
+                      -_GLFW_DECORATION_WIDTH, window->wl.height,
+                      window->wl.width + _GLFW_DECORATION_HORIZONTAL, _GLFW_DECORATION_WIDTH);
+ }
++#endif
+ 
++#ifndef WITH_DECORATION
+ static void destroyDecoration(_GLFWdecorationWayland* decoration)
+ {
+     if (decoration->subsurface)
+@@ -256,7 +270,14 @@ static void destroyDecoration(_GLFWdecorationWayland* decoration)
+     decoration->subsurface = NULL;
+     decoration->viewport = NULL;
+ }
++#endif
+ 
++#ifdef WITH_DECORATION
++static void destroyDecorations(_GLFWwindow* window)
++{
++    //
++}
++#else
+ static void destroyDecorations(_GLFWwindow* window)
+ {
+     destroyDecoration(&window->wl.decorations.top);
+@@ -264,6 +285,7 @@ static void destroyDecorations(_GLFWwindow* window)
+     destroyDecoration(&window->wl.decorations.right);
+     destroyDecoration(&window->wl.decorations.bottom);
+ }
++#endif
+ 
+ static void xdgDecorationHandleConfigure(void* data,
+                                          struct zxdg_toplevel_decoration_v1* decoration,
+@@ -271,9 +293,11 @@ static void xdgDecorationHandleConfigure(void* data,
+ {
+     _GLFWwindow* window = data;
+ 
+-    window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+-
+-    if (!window->wl.decorations.serverSide)
++#ifdef WITH_DECORATION
++    if (!(window->wl.ssd = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)))
++#else
++    if (!(window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)))
++#endif
+         createDecorations(window);
+ }
+ 
+@@ -307,6 +331,7 @@ static void resizeWindow(_GLFWwindow* window)
+     _glfwInputFramebufferSize(window, scaledWidth, scaledHeight);
+     _glfwInputWindowContentScale(window, scale, scale);
+ 
++#ifndef WITH_DECORATION
+     if (!window->wl.decorations.top.surface)
+         return;
+ 
+@@ -333,6 +358,7 @@ static void resizeWindow(_GLFWwindow* window)
+     wp_viewport_set_destination(window->wl.decorations.bottom.viewport,
+                                 window->wl.width + _GLFW_DECORATION_HORIZONTAL, _GLFW_DECORATION_WIDTH);
+     wl_surface_commit(window->wl.decorations.bottom.surface);
++#endif
+ }
+ 
+ static void checkScaleChange(_GLFWwindow* window)
+@@ -465,7 +491,11 @@ static void setFullscreen(_GLFWwindow* window, _GLFWmonitor* monitor,
+             monitor->wl.output);
+     }
+     setIdleInhibitor(window, GLFW_TRUE);
++#ifdef WITH_DECORATION
++    if (!window->wl.ssd)
++#else
+     if (!window->wl.decorations.serverSide)
++#endif
+         destroyDecorations(window);
+ }
+ 
+@@ -573,7 +603,11 @@ static void setXdgDecorations(_GLFWwindow* window)
+     }
+     else
+     {
++#ifdef WITH_DECORATION
++        window->wl.ssd = GLFW_FALSE;
++#else
+         window->wl.decorations.serverSide = GLFW_FALSE;
++#endif
+         createDecorations(window);
+     }
+ }
+@@ -689,8 +723,12 @@ static void incrementCursorImage(_GLFWwindow* window)
+ {
+     _GLFWcursor* cursor;
+ 
+-    if (!window || window->wl.decorations.focus != mainWindow)
++    if (!window) return;
++
++#ifndef WITH_DECORATION
++    if (window->wl.decorations.focus != mainWindow)
+         return;
++#endif
+ 
+     cursor = window->wl.currentCursor;
+     if (cursor && cursor->wl.cursor)
+@@ -860,9 +898,10 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
+     destroyDecorations(window);
+     if (window->wl.xdg.decoration)
+         zxdg_toplevel_decoration_v1_destroy(window->wl.xdg.decoration);
+-
++#ifndef WITH_DECORATION
+     if (window->wl.decorations.buffer)
+         wl_buffer_destroy(window->wl.decorations.buffer);
++#endif
+ 
+     if (window->wl.native)
+         wl_egl_window_destroy(window->wl.native);
+@@ -967,6 +1006,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
+                                      int* left, int* top,
+                                      int* right, int* bottom)
+ {
++#ifndef WITH_DECORATION
+     if (window->decorated && !window->monitor && !window->wl.decorations.serverSide)
+     {
+         if (top)
+@@ -978,6 +1018,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
+         if (bottom)
+             *bottom = _GLFW_DECORATION_WIDTH;
+     }
++#endif
+ }
+ 
+ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
+@@ -1461,10 +1502,14 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
+ 
+     window->wl.currentCursor = cursor;
+ 
++    if (window != _glfw.wl.pointerFocus) return;
++
++#ifndef WITH_DECORATION
+     // If we're not in the correct window just save the cursor
+     // the next time the pointer enters the window the cursor will change
+-    if (window != _glfw.wl.pointerFocus || window->wl.decorations.focus != mainWindow)
++    if (window->wl.decorations.focus != mainWindow)
+         return;
++#endif
+ 
+     // Unlock possible pointer lock if no longer disabled.
+     if (window->cursorMode != GLFW_CURSOR_DISABLED && isPointerLocked(window))
+
+From 666d780db3f4a2ee6b3ee787fd684459b90b4cd8 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Mon, 10 Feb 2020 00:59:44 +0000
+Subject: [PATCH 8/8] wl: add decorations
+
+---
+ src/wl_init.c     |  64 +++++++++--
+ src/wl_platform.h |  19 +++-
+ src/wl_window.c   | 271 +++++++++++++++++++++++++++++++++-------------
+ 3 files changed, 265 insertions(+), 89 deletions(-)
+
+diff --git a/src/wl_init.c b/src/wl_init.c
+index d49e44e77b..b6cdb39dd2 100644
 --- a/src/wl_init.c
 +++ b/src/wl_init.c
 @@ -44,11 +44,14 @@
@@ -98,8 +543,19 @@ index 1ba497b7..b6cdb39d 100644
  static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
                                                      int* which)
  {
-@@ -82,6 +85,20 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+@@ -56,7 +59,6 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+     _GLFWwindow* window = _glfw.windowListHead;
+     if (!which)
+         which = &focus;
+-#ifndef WITH_DECORATION
+     while (window)
+     {
+         if (surface == window->wl.decorations.top.surface)
+@@ -81,9 +83,22 @@ static _GLFWwindow* findWindowFromDecorationSurface(struct wl_surface* surface,
+         }
+         window = window->next;
      }
+-#endif
      return window;
  }
 +#endif
@@ -119,7 +575,7 @@ index 1ba497b7..b6cdb39d 100644
  
  static void pointerHandleEnter(void* data,
                                 struct wl_pointer* pointer,
-@@ -94,8 +111,16 @@ static void pointerHandleEnter(void* data,
+@@ -96,8 +111,16 @@ static void pointerHandleEnter(void* data,
      if (!surface)
          return;
  
@@ -137,16 +593,15 @@ index 1ba497b7..b6cdb39d 100644
      if (!window)
      {
          window = findWindowFromDecorationSurface(surface, &focus);
-@@ -104,6 +129,8 @@ static void pointerHandleEnter(void* data,
+@@ -105,7 +128,6 @@ static void pointerHandleEnter(void* data,
+             return;
      }
  
+-#ifndef WITH_DECORATION
      window->wl.decorations.focus = focus;
-+#endif
-+
-     _glfw.wl.serial = serial;
-     _glfw.wl.pointerFocus = window;
+ #endif
  
-@@ -191,9 +218,16 @@ static void pointerHandleMotion(void* data,
+@@ -196,10 +218,16 @@ static void pointerHandleMotion(void* data,
  
      if (window->cursorMode == GLFW_CURSOR_DISABLED)
          return;
@@ -154,6 +609,7 @@ index 1ba497b7..b6cdb39d 100644
      x = wl_fixed_to_double(sx);
      y = wl_fixed_to_double(sy);
  
+-#ifndef WITH_DECORATION
 +#ifdef WITH_DECORATION
 +    window->wl.cursorPosX = x;
 +    window->wl.cursorPosY = y;
@@ -163,15 +619,7 @@ index 1ba497b7..b6cdb39d 100644
      switch (window->wl.decorations.focus)
      {
          case mainWindow:
-@@ -231,6 +265,7 @@ static void pointerHandleMotion(void* data,
-         default:
-             assert(0);
-     }
-+#endif
-     if (_glfw.wl.cursorPreviousName != cursorName)
-         setCursor(window, cursorName);
- }
-@@ -244,10 +279,11 @@ static void pointerHandleButton(void* data,
+@@ -251,11 +279,11 @@ static void pointerHandleButton(void* data,
  {
      _GLFWwindow* window = _glfw.wl.pointerFocus;
      int glfwButton;
@@ -179,20 +627,12 @@ index 1ba497b7..b6cdb39d 100644
  
      if (!window)
          return;
-+#ifndef WITH_DECORATION
+ #ifndef WITH_DECORATION
 +    uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
      if (button == BTN_LEFT)
      {
          switch (window->wl.decorations.focus)
-@@ -306,6 +342,7 @@ static void pointerHandleButton(void* data,
-     // Don’t pass the button to the user if it was related to a decoration.
-     if (window->wl.decorations.focus != mainWindow)
-         return;
-+#endif
- 
-     _glfw.wl.serial = serial;
- 
-@@ -468,13 +505,21 @@ static void keyboardHandleEnter(void* data,
+@@ -477,13 +505,21 @@ static void keyboardHandleEnter(void* data,
      if (!surface)
          return;
  
@@ -214,7 +654,7 @@ index 1ba497b7..b6cdb39d 100644
  
      _glfw.wl.serial = serial;
      _glfw.wl.keyboardFocus = window;
-@@ -769,6 +814,7 @@ static const struct wl_data_device_listener dataDeviceListener = {
+@@ -778,6 +814,7 @@ static const struct wl_data_device_listener dataDeviceListener = {
      dataDeviceHandleSelection,
  };
  
@@ -222,7 +662,7 @@ index 1ba497b7..b6cdb39d 100644
  static void wmBaseHandlePing(void* data,
                               struct xdg_wm_base* wmBase,
                               uint32_t serial)
-@@ -779,6 +825,7 @@ static void wmBaseHandlePing(void* data,
+@@ -788,6 +825,7 @@ static void wmBaseHandlePing(void* data,
  static const struct xdg_wm_base_listener wmBaseListener = {
      wmBaseHandlePing
  };
@@ -230,7 +670,7 @@ index 1ba497b7..b6cdb39d 100644
  
  static void registryHandleGlobal(void* data,
                                   struct wl_registry* registry,
-@@ -827,6 +874,7 @@ static void registryHandleGlobal(void* data,
+@@ -836,6 +874,7 @@ static void registryHandleGlobal(void* data,
                                   &wl_data_device_manager_interface, 1);
          }
      }
@@ -238,15 +678,15 @@ index 1ba497b7..b6cdb39d 100644
      else if (strcmp(interface, "xdg_wm_base") == 0)
      {
          _glfw.wl.wmBase =
-@@ -845,6 +893,7 @@ static void registryHandleGlobal(void* data,
-         _glfw.wl.viewporter =
-             wl_registry_bind(registry, name, &wp_viewporter_interface, 1);
+@@ -849,7 +888,6 @@ static void registryHandleGlobal(void* data,
+                              &zxdg_decoration_manager_v1_interface,
+                              1);
      }
-+#endif
-     else if (strcmp(interface, "zwp_relative_pointer_manager_v1") == 0)
+-#ifndef WITH_DECORATION
+     else if (strcmp(interface, "wp_viewporter") == 0)
      {
-         _glfw.wl.relativePointerManager =
-@@ -1152,12 +1201,14 @@ int _glfwPlatformInit(void)
+         _glfw.wl.viewporter =
+@@ -1163,12 +1201,14 @@ int _glfwPlatformInit(void)
      if (_glfw.wl.seatVersion >= 4)
          _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
  
@@ -261,7 +701,7 @@ index 1ba497b7..b6cdb39d 100644
  
      if (_glfw.wl.pointer && _glfw.wl.shm)
      {
-@@ -1203,6 +1254,10 @@ int _glfwPlatformInit(void)
+@@ -1214,6 +1254,10 @@ int _glfwPlatformInit(void)
          _glfw.wl.clipboardSize = 4096;
      }
  
@@ -272,15 +712,17 @@ index 1ba497b7..b6cdb39d 100644
      return GLFW_TRUE;
  }
  
-@@ -1249,12 +1304,16 @@ void _glfwPlatformTerminate(void)
+@@ -1260,14 +1304,16 @@ void _glfwPlatformTerminate(void)
          wl_compositor_destroy(_glfw.wl.compositor);
      if (_glfw.wl.shm)
          wl_shm_destroy(_glfw.wl.shm);
+-#ifndef WITH_DECORATION
 +#ifdef WITH_DECORATION
 +    libdecor_unref(_glfw.wl.csd_context);
 +#else
      if (_glfw.wl.viewporter)
          wp_viewporter_destroy(_glfw.wl.viewporter);
+-#endif
      if (_glfw.wl.decorationManager)
          zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
      if (_glfw.wl.wmBase)
@@ -290,48 +732,32 @@ index 1ba497b7..b6cdb39d 100644
          wl_data_source_destroy(_glfw.wl.dataSource);
      if (_glfw.wl.dataDevice)
 diff --git a/src/wl_platform.h b/src/wl_platform.h
-index 966155fd..b6b3392e 100644
+index 4591becbd0..b6b3392e49 100644
 --- a/src/wl_platform.h
 +++ b/src/wl_platform.h
-@@ -54,13 +54,18 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
+@@ -54,14 +54,17 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
  #endif
  #include "xkb_unicode.h"
  
--#include "wayland-xdg-shell-client-protocol.h"
--#include "wayland-xdg-decoration-client-protocol.h"
--#include "wayland-viewporter-client-protocol.h"
- #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
- #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
- #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
- 
++#include "wayland-relative-pointer-unstable-v1-client-protocol.h"
++#include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
++#include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
++
 +#ifdef WITH_DECORATION
 +#include <libdecor.h>
 +#else
-+#include "wayland-xdg-shell-client-protocol.h"
-+#include "wayland-xdg-decoration-client-protocol.h"
-+#include "wayland-viewporter-client-protocol.h"
-+#endif
-+
+ #include "wayland-xdg-shell-client-protocol.h"
+ #include "wayland-xdg-decoration-client-protocol.h"
+-#ifndef WITH_DECORATION
+ #include "wayland-viewporter-client-protocol.h"
+ #endif
+-#include "wayland-relative-pointer-unstable-v1-client-protocol.h"
+-#include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
+-#include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
+ 
  #define _glfw_dlopen(name) dlopen(name, RTLD_LAZY | RTLD_LOCAL)
  #define _glfw_dlclose(handle) dlclose(handle)
- #define _glfw_dlsym(handle, name) dlsym(handle, name)
-@@ -146,6 +151,7 @@ typedef xkb_keysym_t (* PFN_xkb_compose_state_get_one_sym)(struct xkb_compose_st
- #define _GLFW_DECORATION_VERTICAL (_GLFW_DECORATION_TOP + _GLFW_DECORATION_WIDTH)
- #define _GLFW_DECORATION_HORIZONTAL (2 * _GLFW_DECORATION_WIDTH)
- 
-+#ifndef WITH_DECORATION
- typedef enum _GLFWdecorationSideWayland
- {
-     mainWindow,
-@@ -163,6 +169,7 @@ typedef struct _GLFWdecorationWayland
-     struct wp_viewport*         viewport;
- 
- } _GLFWdecorationWayland;
-+#endif
- 
- // Wayland-specific per-window data
- //
-@@ -177,11 +184,13 @@ typedef struct _GLFWwindowWayland
+@@ -181,11 +184,13 @@ typedef struct _GLFWwindowWayland
      struct wl_egl_window*       native;
      struct wl_callback*         callback;
  
@@ -345,24 +771,16 @@ index 966155fd..b6b3392e 100644
  
      _GLFWcursor*                currentCursor;
      double                      cursorPosX, cursorPosY;
-@@ -204,12 +213,16 @@ typedef struct _GLFWwindowWayland
- 
-     GLFWbool                    wasFullscreen;
- 
-+#ifndef WITH_DECORATION
-     struct {
-         GLFWbool                           serverSide;
-         struct wl_buffer*                  buffer;
-         _GLFWdecorationWayland             top, left, right, bottom;
+@@ -216,7 +221,7 @@ typedef struct _GLFWwindowWayland
          int                                focus;
      } decorations;
-+#else
+ #else
+-    GLFWbool                                ssd;
 +    struct libdecor_frame                   *decoration_frame;
-+#endif
+ #endif
  
  } _GLFWwindowWayland;
- 
-@@ -229,9 +242,13 @@ typedef struct _GLFWlibraryWayland
+@@ -237,9 +242,11 @@ typedef struct _GLFWlibraryWayland
      struct wl_data_device*      dataDevice;
      struct wl_data_offer*       dataOffer;
      struct wl_data_source*      dataSource;
@@ -371,32 +789,33 @@ index 966155fd..b6b3392e 100644
 +#else
      struct xdg_wm_base*         wmBase;
      struct zxdg_decoration_manager_v1*      decorationManager;
+-#ifndef WITH_DECORATION
      struct wp_viewporter*       viewporter;
-+#endif
+ #endif
      struct zwp_relative_pointer_manager_v1* relativePointerManager;
-     struct zwp_pointer_constraints_v1*      pointerConstraints;
-     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
 diff --git a/src/wl_window.c b/src/wl_window.c
-index 939f9c19..47cc1437 100644
+index 9e10e8a3fd..47cc14377c 100644
 --- a/src/wl_window.c
 +++ b/src/wl_window.c
-@@ -40,6 +40,12 @@
- #include <sys/timerfd.h>
+@@ -41,10 +41,12 @@
  #include <poll.h>
  
-+#ifdef WITH_DECORATION
+ #ifdef WITH_DECORATION
+-#include <libdecoration.h>
 +#include <libdecor.h>
-+#endif
-+
-+
-+extern const char *proxy_tag;
+ #endif
  
+ 
++extern const char *proxy_tag;
++
  static int createTmpfileCloexec(char* tmpname)
  {
-@@ -182,6 +188,61 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
+     int fd;
+@@ -186,7 +188,61 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
      return buffer;
  }
  
+-#ifndef WITH_DECORATION
 +#ifdef WITH_DECORATION
 +static void resizeWindow(_GLFWwindow* window);
 +void frame_configure(struct libdecor_frame *frame, struct libdecor_configuration *configuration, void *user_data)
@@ -455,11 +874,49 @@ index 939f9c19..47cc1437 100644
  static void createDecoration(_GLFWdecorationWayland* decoration,
                               struct wl_surface* parent,
                               struct wl_buffer* buffer, GLFWbool opaque,
-@@ -264,22 +325,23 @@ static void destroyDecorations(_GLFWwindow* window)
-     destroyDecoration(&window->wl.decorations.right);
-     destroyDecoration(&window->wl.decorations.bottom);
+@@ -216,14 +272,7 @@ static void createDecoration(_GLFWdecorationWayland* decoration,
+     else
+         wl_surface_commit(decoration->surface);
  }
-+#endif
+-#endif
+ 
+-#ifdef WITH_DECORATION
+-static void createDecorations(_GLFWwindow* window)
+-{
+-    //
+-}
+-#else
+ static void createDecorations(_GLFWwindow* window)
+ {
+     unsigned char data[] = { 224, 224, 224, 255 };
+@@ -255,9 +304,7 @@ static void createDecorations(_GLFWwindow* window)
+                      -_GLFW_DECORATION_WIDTH, window->wl.height,
+                      window->wl.width + _GLFW_DECORATION_HORIZONTAL, _GLFW_DECORATION_WIDTH);
+ }
+-#endif
+ 
+-#ifndef WITH_DECORATION
+ static void destroyDecoration(_GLFWdecorationWayland* decoration)
+ {
+     if (decoration->subsurface)
+@@ -270,14 +317,7 @@ static void destroyDecoration(_GLFWdecorationWayland* decoration)
+     decoration->subsurface = NULL;
+     decoration->viewport = NULL;
+ }
+-#endif
+ 
+-#ifdef WITH_DECORATION
+-static void destroyDecorations(_GLFWwindow* window)
+-{
+-    //
+-}
+-#else
+ static void destroyDecorations(_GLFWwindow* window)
+ {
+     destroyDecoration(&window->wl.decorations.top);
+@@ -287,23 +327,21 @@ static void destroyDecorations(_GLFWwindow* window)
+ }
+ #endif
  
 +#ifndef WITH_DECORATION
  static void xdgDecorationHandleConfigure(void* data,
@@ -468,10 +925,11 @@ index 939f9c19..47cc1437 100644
  {
      _GLFWwindow* window = data;
  
--    window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
--
--    if (!window->wl.decorations.serverSide)
-+    if (!(window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)))
+-#ifdef WITH_DECORATION
+-    if (!(window->wl.ssd = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)))
+-#else
+     if (!(window->wl.decorations.serverSide = (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)))
+-#endif
          createDecorations(window);
  }
  
@@ -482,31 +940,7 @@ index 939f9c19..47cc1437 100644
  
  // Makes the surface considered as XRGB instead of ARGB.
  static void setOpaqueRegion(_GLFWwindow* window)
-@@ -292,7 +354,6 @@ static void setOpaqueRegion(_GLFWwindow* window)
- 
-     wl_region_add(region, 0, 0, window->wl.width, window->wl.height);
-     wl_surface_set_opaque_region(window->wl.surface, region);
--    wl_surface_commit(window->wl.surface);
-     wl_region_destroy(region);
- }
- 
-@@ -308,6 +369,7 @@ static void resizeWindow(_GLFWwindow* window)
-     _glfwInputFramebufferSize(window, scaledWidth, scaledHeight);
-     _glfwInputWindowContentScale(window, scale, scale);
- 
-+#ifndef WITH_DECORATION
-     if (!window->wl.decorations.top.surface)
-         return;
- 
-@@ -334,6 +396,7 @@ static void resizeWindow(_GLFWwindow* window)
-     wp_viewport_set_destination(window->wl.decorations.bottom.viewport,
-                                 window->wl.width + _GLFW_DECORATION_HORIZONTAL, _GLFW_DECORATION_WIDTH);
-     wl_surface_commit(window->wl.decorations.bottom.surface);
-+#endif
- }
- 
- static void checkScaleChange(_GLFWwindow* window)
-@@ -367,6 +430,9 @@ static void surfaceHandleEnter(void *data,
+@@ -392,6 +430,9 @@ static void surfaceHandleEnter(void *data,
                                 struct wl_surface *surface,
                                 struct wl_output *output)
  {
@@ -516,7 +950,7 @@ index 939f9c19..47cc1437 100644
      _GLFWwindow* window = data;
      _GLFWmonitor* monitor = wl_output_get_user_data(output);
  
-@@ -387,6 +453,9 @@ static void surfaceHandleLeave(void *data,
+@@ -412,6 +453,9 @@ static void surfaceHandleLeave(void *data,
                                 struct wl_surface *surface,
                                 struct wl_output *output)
  {
@@ -526,7 +960,7 @@ index 939f9c19..47cc1437 100644
      _GLFWwindow* window = data;
      _GLFWmonitor* monitor = wl_output_get_user_data(output);
      GLFWbool found;
-@@ -427,8 +496,7 @@ static void setIdleInhibitor(_GLFWwindow* window, GLFWbool enable)
+@@ -452,8 +496,7 @@ static void setIdleInhibitor(_GLFWwindow* window, GLFWbool enable)
      }
  }
  
@@ -536,7 +970,7 @@ index 939f9c19..47cc1437 100644
  {
      window->wl.surface = wl_compositor_create_surface(_glfw.wl.compositor);
      if (!window->wl.surface)
-@@ -439,37 +507,60 @@ static GLFWbool createSurface(_GLFWwindow* window,
+@@ -464,41 +507,60 @@ static GLFWbool createSurface(_GLFWwindow* window,
                              window);
  
      wl_surface_set_user_data(window->wl.surface, window);
@@ -592,8 +1026,12 @@ index 939f9c19..47cc1437 100644
      }
 +#endif
      setIdleInhibitor(window, GLFW_TRUE);
+-#ifdef WITH_DECORATION
+-    if (!window->wl.ssd)
+-#else
 +#ifndef WITH_DECORATION
      if (!window->wl.decorations.serverSide)
+-#endif
          destroyDecorations(window);
 +#endif
  }
@@ -603,7 +1041,19 @@ index 939f9c19..47cc1437 100644
  static void xdgToplevelHandleConfigure(void* data,
                                         struct xdg_toplevel* toplevel,
                                         int32_t width,
-@@ -639,6 +730,7 @@ static GLFWbool createXdgSurface(_GLFWwindow* window)
+@@ -603,11 +665,7 @@ static void setXdgDecorations(_GLFWwindow* window)
+     }
+     else
+     {
+-#ifdef WITH_DECORATION
+-        window->wl.ssd = GLFW_FALSE;
+-#else
+         window->wl.decorations.serverSide = GLFW_FALSE;
+-#endif
+         createDecorations(window);
+     }
+ }
+@@ -672,6 +730,7 @@ static GLFWbool createXdgSurface(_GLFWwindow* window)
  
      return GLFW_TRUE;
  }
@@ -611,21 +1061,7 @@ index 939f9c19..47cc1437 100644
  
  static void setCursorImage(_GLFWwindow* window,
                             _GLFWcursorWayland* cursorWayland)
-@@ -690,8 +782,12 @@ static void incrementCursorImage(_GLFWwindow* window)
- {
-     _GLFWcursor* cursor;
- 
--    if (!window || window->wl.decorations.focus != mainWindow)
-+    if (!window) return;
-+
-+#ifndef WITH_DECORATION
-+    if (window->wl.decorations.focus != mainWindow)
-         return;
-+#endif
- 
-     cursor = window->wl.currentCursor;
-     if (cursor && cursor->wl.cursor)
-@@ -788,7 +884,17 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+@@ -825,7 +884,17 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
  {
      window->wl.transparent = fbconfig->transparent;
  
@@ -644,7 +1080,7 @@ index 939f9c19..47cc1437 100644
          return GLFW_FALSE;
  
      if (ctxconfig->client != GLFW_NO_API)
-@@ -810,9 +916,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+@@ -847,9 +916,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
          }
      }
  
@@ -655,7 +1091,7 @@ index 939f9c19..47cc1437 100644
      if (wndconfig->visible)
      {
          if (!createXdgSurface(window))
-@@ -826,6 +930,19 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+@@ -863,6 +930,16 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
          window->wl.xdg.toplevel = NULL;
          window->wl.visible = GLFW_FALSE;
      }
@@ -669,13 +1105,10 @@ index 939f9c19..47cc1437 100644
 +    _glfwPlatformSetWindowTitle(window, wndconfig->title);
 +
 +    _glfwPlatformSetWindowResizable(window, wndconfig->resizable);
-+
-+    if (window->monitor)
-+        setFullscreen(window, window->monitor, window->videoMode.refreshRate);
  
-     window->wl.currentCursor = NULL;
- 
-@@ -833,6 +950,8 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
+     if (window->monitor)
+         setFullscreen(window, window->monitor, window->videoMode.refreshRate);
+@@ -873,6 +950,8 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
      window->wl.monitorsCount = 0;
      window->wl.monitorsSize = 1;
  
@@ -684,7 +1117,7 @@ index 939f9c19..47cc1437 100644
      return GLFW_TRUE;
  }
  
-@@ -856,20 +975,25 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
+@@ -896,9 +975,11 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
          window->context.destroy(window);
  
      destroyDecorations(window);
@@ -693,11 +1126,11 @@ index 939f9c19..47cc1437 100644
 +#else
      if (window->wl.xdg.decoration)
          zxdg_toplevel_decoration_v1_destroy(window->wl.xdg.decoration);
--
+-#ifndef WITH_DECORATION
      if (window->wl.decorations.buffer)
          wl_buffer_destroy(window->wl.decorations.buffer);
-+#endif
- 
+ #endif
+@@ -906,11 +987,13 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
      if (window->wl.native)
          wl_egl_window_destroy(window->wl.native);
  
@@ -711,7 +1144,7 @@ index 939f9c19..47cc1437 100644
  
      if (window->wl.surface)
          wl_surface_destroy(window->wl.surface);
-@@ -883,8 +1007,15 @@ void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title)
+@@ -924,8 +1007,15 @@ void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title)
      if (window->wl.title)
          free(window->wl.title);
      window->wl.title = _glfw_strdup(title);
@@ -729,7 +1162,7 @@ index 939f9c19..47cc1437 100644
  }
  
  void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
-@@ -930,16 +1061,23 @@ void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
+@@ -971,16 +1061,23 @@ void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
                                        int minwidth, int minheight,
                                        int maxwidth, int maxheight)
  {
@@ -758,23 +1191,7 @@ index 939f9c19..47cc1437 100644
  }
  
  void _glfwPlatformSetWindowAspectRatio(_GLFWwindow* window,
-@@ -965,6 +1103,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
-                                      int* left, int* top,
-                                      int* right, int* bottom)
- {
-+#ifndef WITH_DECORATION
-     if (window->decorated && !window->monitor && !window->wl.decorations.serverSide)
-     {
-         if (top)
-@@ -976,6 +1115,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
-         if (bottom)
-             *bottom = _GLFW_DECORATION_WIDTH;
-     }
-+#endif
- }
- 
- void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
-@@ -989,31 +1129,37 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
+@@ -1032,31 +1129,37 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
  
  void _glfwPlatformIconifyWindow(_GLFWwindow* window)
  {
@@ -827,7 +1244,7 @@ index 939f9c19..47cc1437 100644
      window->wl.maximized = GLFW_TRUE;
  }
  
-@@ -1021,13 +1167,18 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
+@@ -1064,13 +1167,18 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
  {
      if (!window->wl.visible)
      {
@@ -847,7 +1264,7 @@ index 939f9c19..47cc1437 100644
      if (window->wl.xdg.toplevel)
      {
          xdg_toplevel_destroy(window->wl.xdg.toplevel);
-@@ -1035,6 +1186,9 @@ void _glfwPlatformHideWindow(_GLFWwindow* window)
+@@ -1078,6 +1186,9 @@ void _glfwPlatformHideWindow(_GLFWwindow* window)
          window->wl.xdg.toplevel = NULL;
          window->wl.xdg.surface = NULL;
      }
@@ -857,7 +1274,7 @@ index 939f9c19..47cc1437 100644
      window->wl.visible = GLFW_FALSE;
  }
  
-@@ -1063,11 +1217,14 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
+@@ -1106,11 +1217,14 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
      }
      else
      {
@@ -874,7 +1291,7 @@ index 939f9c19..47cc1437 100644
      }
      _glfwInputWindowMonitor(window, monitor);
  }
-@@ -1106,9 +1263,14 @@ int _glfwPlatformFramebufferTransparent(_GLFWwindow* window)
+@@ -1149,9 +1263,14 @@ int _glfwPlatformFramebufferTransparent(_GLFWwindow* window)
  
  void _glfwPlatformSetWindowResizable(_GLFWwindow* window, GLFWbool enabled)
  {
@@ -892,7 +1309,7 @@ index 939f9c19..47cc1437 100644
  }
  
  void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
-@@ -1124,9 +1286,13 @@ void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
+@@ -1167,9 +1286,13 @@ void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
  
  void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
  {
@@ -909,22 +1326,3 @@ index 939f9c19..47cc1437 100644
  }
  
  void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow* window, GLFWbool enabled)
-@@ -1459,10 +1625,14 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
- 
-     window->wl.currentCursor = cursor;
- 
-+    if (window != _glfw.wl.pointerFocus) return;
-+
-+#ifndef WITH_DECORATION
-     // If we're not in the correct window just save the cursor
-     // the next time the pointer enters the window the cursor will change
--    if (window != _glfw.wl.pointerFocus || window->wl.decorations.focus != mainWindow)
-+    if (window->wl.decorations.focus != mainWindow)
-         return;
-+#endif
- 
-     // Unlock possible pointer lock if no longer disabled.
-     if (window->cursorMode != GLFW_CURSOR_DISABLED && isPointerLocked(window))
--- 
-2.32.0
-

--- a/patches/0002-set-O_NONBLOCK-on-repeat-timerfd.patch
+++ b/patches/0002-set-O_NONBLOCK-on-repeat-timerfd.patch
@@ -1,0 +1,28 @@
+From 169d911ab575c7efab203e91db03c325b20d14e4 Mon Sep 17 00:00:00 2001
+From: Stone Tickle <lattis@mochiro.moe>
+Date: Fri, 5 Jun 2020 12:51:25 +0900
+Subject: [PATCH 2/4] set O_NONBLOCK on repeat timerfd
+
+---
+ src/wl_init.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/wl_init.c b/src/wl_init.c
+index b6cdb39d..f092aef4 100644
+--- a/src/wl_init.c
++++ b/src/wl_init.c
+@@ -1198,8 +1198,9 @@ int _glfwPlatformInit(void)
+     _glfwInitTimerPOSIX();
+ 
+     _glfw.wl.timerfd = -1;
+-    if (_glfw.wl.seatVersion >= 4)
+-        _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
++    if (_glfw.wl.seatVersion >= 4) {
++        _glfw.wl.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
++    }
+ 
+ #ifndef WITH_DECORATION
+     if (!_glfw.wl.wmBase)
+-- 
+2.32.0
+

--- a/patches/0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch
+++ b/patches/0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch
@@ -1,0 +1,39 @@
+From 8400d399b74f55bf128488f7ea73609babbf4eaf Mon Sep 17 00:00:00 2001
+From: ninja- <ninja-@users.noreply.github.com>
+Date: Tue, 30 Jun 2020 19:41:48 +0200
+Subject: [PATCH 3/4] wayland: don't crash app on api calls to window focus or
+ window icon - just ignore them
+
+---
+ src/wl_window.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 47cc1437..f3bda65b 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -1021,8 +1021,8 @@ void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title)
+ void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
+                                 int count, const GLFWimage* images)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the window icon");
++    // _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
++    //                 "Wayland: The platform does not support setting the window icon");
+ }
+ 
+ void _glfwPlatformGetWindowPos(_GLFWwindow* window, int* xpos, int* ypos)
+@@ -1201,8 +1201,8 @@ void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+ 
+ void _glfwPlatformFocusWindow(_GLFWwindow* window)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the input focus");
++    // _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
++    //                 "Wayland: The platform does not support setting the input focus");
+ }
+ 
+ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
+-- 
+2.32.0
+

--- a/patches/0004-fix-broken-opengl-screenshots-on-mutter.patch
+++ b/patches/0004-fix-broken-opengl-screenshots-on-mutter.patch
@@ -1,0 +1,33 @@
+From 4d47891ca1f3979c20f0acc3539a80d8fa97a2ad Mon Sep 17 00:00:00 2001
+From: ninja- <ninja-@users.noreply.github.com>
+Date: Tue, 30 Jun 2020 19:41:52 +0200
+Subject: [PATCH 4/4] fix broken opengl screenshots on mutter
+
+(admicos) This breaks more than just screenshots. On sway, the window is
+rendered half transparent. And we do not want that.
+---
+ src/egl_context.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/egl_context.c b/src/egl_context.c
+index 975c67be..b5cbeaff 100644
+--- a/src/egl_context.c
++++ b/src/egl_context.c
+@@ -175,6 +175,14 @@ static GLFWbool chooseEGLConfig(const _GLFWctxconfig* ctxconfig,
+         u->samples = getEGLConfigAttrib(n, EGL_SAMPLES);
+         u->doublebuffer = desired->doublebuffer;
+ 
++#if defined(_GLFW_WAYLAND)
++        // Avoid using transparent buffer on Wayland if transparency is not requested.
++        // Otherwise mutter will fail to properly screenshot OpenGL content.
++        if (u->alphaBits > 0 && !desired->transparent) {
++            continue;
++        }
++#endif // _GLFW_WAYLAND
++
+         u->handle = (uintptr_t) n;
+         usableCount++;
+     }
+-- 
+2.32.0
+


### PR DESCRIPTION
https://github.com/flathub/com.mojang.Minecraft/pull/85 is an older version, ignore that one.

Adds native Wayland support thanks to the [work that's gathered here](https://github.com/Admicos/minecraft-wayland). Nothing is changed by default, a user specifically has to opt in by adding a JVM flag in the launcher. Should work in 1.13+, including 1.17 (see picture).

This is done so the GLFW patches can be tested. The goal is not to have to ship a patched GLFW, but to help get them upstreamed. If possible, please test out this build following these instructions and report issues where appropriate.

Fixes #84

![Minecraft in Native Wayland](https://user-images.githubusercontent.com/38842733/124009243-37d39d80-d992-11eb-93f9-973b4d172045.png)


### To use: 
1. git clone my fork and then `flatpak-builder --user --install build-dir com.mojang.Minecraft.json`
2. Within the Minecraft launcher’s "Installations" menu, hover over an installation and click the 3 dots. Click edit, and then open advanced options near the bottom. Append `-Dorg.lwjgl.glfw.libname=/app/lib/libglfw.so` to your JVM arguments. Ensure to leave a space in between arguments.
3. Click play!

### Issues: 

- [x]  No proper decorations on GNOME Wayland. 
- I have been unable to include [the patch for libdecoration](https://github.com/glfw/glfw/pull/1693). It appears the patch itself is broken, but [I am trying to confirm that](https://github.com/Admicos/minecraft-wayland/issues/2).
- Until then GNOME users will likely not have a great experience, since Minecraft does not have CSD support without the patch.
- Even when this patch is merged we still won't have gtk-style window decorations, to do so the GLFW patch needs to be updated to use [this libdecoration change](https://gitlab.gnome.org/jadahl/libdecoration/-/merge_requests/8).
- [x] Weird rectangle that shows up on my HIDPI monitor in GNOME Wayland.
- Only occurs when libdecor is not included.
- [ ] On my HIDPI setup, Minecraft seems to incorrectly always pick my smaller and lower resolution monitor when clicking fullscreen within the game settings. The only way to override this behaviour is to disable the lower resolution monitor.
- [ ] Sometimes the cursor gets displaced when full screening. If this happens you can try unfullscreening by using tab and arrow keys to navigate controls.
- [ ] There is a general blur to their entire window when libdecor is there. [Compare them using this diff](https://github.com/vchernin/minecraft-wayland-misc/commit/bad6665a4c0204ec66d25158c2800ce883a86357?short_path=53f499b#diff-53f499be91bd991915f5bf5e2e55f2e9b8858bd706ccf8755ed9743d10f35cf1), click "Swipe" at the bottom. The image on the right is with the libdecor patch, the one on the left is without. You might need to zoom in if it's not obvious.

Unimportant (since long-term we shouldn't want any custom glfw):
- [ ] The only way I know to get the JVM to use the patched GLFW is with the instructions above. I don't know how to set JVM flags within the Flatpak config. For now we shouldn't anyhow, but it is something I'd like to figure out.
- The flag appended requires manually setting your user, $USER doesn't work. This should be improved somehow.
- [ ] The way I give Minecraft permission in df5340f to read the patched library is not ideal. It took me a while to figure out what exactly I needed to give it. I feel like this is a bug, since shouldn't the Flatpak always have permission to read it's own directories?
- The .local directory is given in case it's installed with for a user, the other is in case it's installed system-wide.

### Patch Info:
The Flatpak uses [the patches gathered here (libdecoration branch)](https://github.com/Admicos/minecraft-wayland), which were originally from the following GLFW changes:
|Patch | Original PR/Commit  | Purpose|
--- | --- | ---
|0001|[PR](https://github.com/glfw/glfw/pull/1693)|Add libdecoration support to get CSD on GNOME|
|0002|[PR](https://github.com/glfw/glfw/pull/1711)|Fixes freeze caused by race condition|
|0003|[Commit](https://github.com/glfw/glfw/pull/1725/commits/e89e9aee41382508ed36594a4b028239cad5197b)|Don't crash on window focus or icons|
|0004|[Commit](https://github.com/glfw/glfw/pull/1725/commits/2227df83f032ee7868c39fc983749a3fcdc22c7b)|Fixes broken Mutter (GNOME) OpenGL screenshots|

### Todo:
- Debug issues and report them upstream. 