### PR TITLE
Set XCURSOR_PATH to both host and user icon directories (#95)

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -14,8 +14,9 @@
         "--share=ipc",
         "--device=dri",
         "--socket=pulseaudio",
-        "--share=network"
-        ],
+        "--share=network",
+        "--env=XCURSOR_PATH=/run/host/share/icons:/run/host/user-share/icons"
+    ],
     "modules": [
         {
             "name": "xrandr",


### PR DESCRIPTION
This pull request sets the `XCURSOR_PATH` environment variable, which should fix the cursor icon theme being incorrect.

Flatpak exposes the host's system and user icons inside of the Flatpak at `/run/host/share/icons` and `/run/host/user-share/icons`. See [`1ee74fc`](https://github.com/flatpak/flatpak/commit/1ee74fc) and [`ad87b12`](https://github.com/flatpak/flatpak/commit/ad87b12). These paths are added to the `XDG_DATA_DIRS` environment variable so that applications may find them. But, [Chromium hard-codes the paths of system and user icons](https://source.chromium.org/chromium/chromium/src/+/refs/tags/96.0.4646.2:ui/base/x/x11_cursor_loader.cc;l=153), so it cannot locate these icons. However, this behavior can be overridden using the [`XCURSOR_PATH` environment variable](https://source.chromium.org/chromium/chromium/src/+/refs/tags/96.0.4646.2:ui/base/x/x11_cursor_loader.cc;l=162). By setting the `XCURSOR_PATH` environment variable to the Flatpak-exposed system and user icons, the cursor icon theme should now be correct inside of the launcher.

Fixes #95.