### PR TITLE
Gamescope extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Minecraft (Flatpak)
 
-#### Resource Packs, Mods etc.
+### Resource Packs, Mods etc.
 
 You can install these to `~/.var/app/com.mojang.Minecraft/.minecraft`.
+
+### Gamescope
+You can run with [Gamescope](https://github.com/Plagman/gamescope) by installing the Gamescope extension, and creating `gamescope.txt`  
+Enter:  
+```
+flatpak install flathub com.valvesoftware.Steam.Utility.gamescope
+touch ~/.var/app/com.mojang.Minecraft/.minecraft/gamescope.txt
+```
+
+Optionally to pass custom [Gamescope arguments](https://github.com/Plagman/gamescope#examples), add flags to `~/.var/app/com.mojang.Minecraft/.minecraft/gamescope.txt`
+
+For example, to run at 1280x720 in fullscreen put `-w 1280 -h 720 -f` in `~/.var/app/com.mojang.Minecraft/.minecraft/gamescope.txt`  
+Do not put `-- %command%`, that is for Steam.

--- a/com.mojang.Minecraft.desktop
+++ b/com.mojang.Minecraft.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Minecraft
 Icon=com.mojang.Minecraft
-Exec=minecraft
+Exec=minecraft-wrapper
 Categories=Game;
 StartupWMClass=net-minecraft-bootstrap-Bootstrap

--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -3,7 +3,7 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
-    "command": "minecraft",
+    "command": "minecraft-wrapper",
     "separate-locales": false,
     "tags": [
         "proprietary"
@@ -17,6 +17,18 @@
         "--share=network",
         "--env=XCURSOR_PATH=/run/host/share/icons:/run/host/user-share/icons"
     ],
+    "add-extensions": {
+        "com.valvesoftware.Steam.Utility": {
+            "subdirectories": true,
+            "directory": "utils",
+            "version": "stable",
+            "versions": "stable;beta;test;master",
+            "add-ld-path": "lib",
+            "merge-dirs": "bin;lib/python3.8/site-packages;share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;",
+            "no-autodownload": true,
+            "autodelete": true
+        }
+    },
     "modules": [
         "shared-modules/libsecret/libsecret.json",
         {
@@ -57,7 +69,9 @@
                 "install -Dp -m 644 com.mojang.Minecraft-64.png /app/share/icons/hicolor/64x64/apps/com.mojang.Minecraft.png",
                 "install -Dp -m 644 com.mojang.Minecraft-128.png /app/share/icons/hicolor/128x128/apps/com.mojang.Minecraft.png",
                 "install -Dp -m 644 com.mojang.Minecraft.png /app/share/icons/hicolor/256x256/apps/com.mojang.Minecraft.png",
-                "install -Dp -m 644 com.mojang.Minecraft.appdata.xml /app/share/appdata/com.mojang.Minecraft.appdata.xml"
+                "install -Dp -m 644 com.mojang.Minecraft.appdata.xml /app/share/appdata/com.mojang.Minecraft.appdata.xml",
+                "mkdir -p /app/utils",
+                "install -Dp -m 755 minecraft-wrapper /app/bin/minecraft-wrapper"
             ],
             "sources": [
                 {
@@ -104,6 +118,10 @@
                 {
                     "type": "file",
                     "path": "com.mojang.Minecraft.appdata.xml"
+                },
+                {
+                    "type": "file",
+                    "path": "minecraft-wrapper"
                 }
             ]
         }

--- a/minecraft
+++ b/minecraft
@@ -23,4 +23,4 @@ if [ ! -f $XDG_DATA_HOME/../.minecraft/.nonxdg-migrated ]; then
     touch $XDG_DATA_HOME/../.minecraft/.nonxdg-migrated
 fi
 
-exec /app/extra/minecraft-launcher/minecraft-launcher $@ --workDir $XDG_DATA_HOME/../.minecraft
+exec /app/extra/minecraft-launcher/minecraft-launcher "$@" --workDir $XDG_DATA_HOME/../.minecraft

--- a/minecraft-wrapper
+++ b/minecraft-wrapper
@@ -1,0 +1,12 @@
+#!/bin/sh 
+
+# verify extension installed and config file exists.
+if test -f "/app/utils/gamescope/bin/gamescope" && test -f "$XDG_DATA_HOME/../.minecraft/gamescope.txt"; then    
+
+    echo "Gamescope extension installed and ~/.var/app/com.mojang.Minecraft/.minecraft/gamescope.txt exists, attempting to run with Gamescope"
+    echo "If wanted, put Gamescope arguments in ~/.var/app/com.mojang.Minecraft/.minecraft/gamescope.txt"
+    /app/utils/gamescope/bin/gamescope $(cat "$XDG_DATA_HOME"/../.minecraft/gamescope.txt) minecraft
+
+else
+    minecraft
+fi


### PR DESCRIPTION
- Uses minecraft-wrapper to launch game. Needed to be able to execute gamescope command, then pass the launcher to that.
Attempting to execute everything in one line doesn't work, since --workDir is recognized as a Gamescope flag not a Minecraft Launcher flag.
- Add extension point for com.valvesoftware.Steam.Utility.
- Make sure /app/utils is present.
- Add some README info about this.

Todo:
- [ ] verify migration is still working, script changes may have interfered
- [ ] Gamescope with launcher doesn't like to be force quit/killed, doing so causes subsequent gamescope launches to fail. The problem is there is no clean way to close the launcher, since the launcher is also being run through gamescope. 
- - Workaround: delete the file, launch Minecraft (without gamescope) and recreate gamescope file. Or launch it, run the game and only exit from in game (don't try to exit the launcher).
- - The real solution is to natively integrate gamescope within the launcher, but that seems like a whole new challenge.
- [ ] Wayland socket?