### PR TITLE
Set PrefersNonDefaultGPU to true

### DIFF
--- a/com.mojang.Minecraft.desktop
+++ b/com.mojang.Minecraft.desktop
@@ -5,3 +5,4 @@ Icon=com.mojang.Minecraft
 Exec=minecraft
 Categories=Game;
 StartupWMClass=net-minecraft-bootstrap-Bootstrap
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
This PR sets `PrefersNonDefaultGPU` to `true` in the desktop file, making discrete GPUs the default option for launching on most systems