### PR TITLE
Give access to xdg-download due to skin changer

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -15,7 +15,8 @@
         "--device=dri",
         "--socket=pulseaudio",
         "--share=network",
-        "--env=XCURSOR_PATH=/run/host/share/icons:/run/host/user-share/icons"
+        "--env=XCURSOR_PATH=/run/host/share/icons:/run/host/user-share/icons",
+        "--filesystem=xdg-download:ro"
     ],
     "modules": [
         "shared-modules/libsecret/libsecret.json",


### PR DESCRIPTION
The skin changer in the launcher is quite useless without permission to any directories. The average joe will most likely put their skin in their downloads folder, so allowing the launcher read only access to that folder just seems natural.