### PR TITLE
Set LC_ALL=C env variable

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -16,6 +16,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--env=XCURSOR_PATH=/run/host/share/icons:/run/host/user-share/icons",
+        "--env=LC_ALL=C",
         "--filesystem=xdg-download:ro",
         "--filesystem=xdg-run/app/com.discordapp.Discord:create"
     ],


### PR DESCRIPTION
Fixes #6 and #25 

The minecraft launcher doesn't seem to pick the language after what locale the system has set. I am at least not able to make it select norwegian bokmål automatically.

When it comes to the env variable it wants us to set. It doesn't care about any of the LC_* variables. It wants LANG to be set to something it knows. Setting it to nn_NO.UTF-8 (norwegian nynorsk) makes it crash, however with nb_NO (norwegian bokmål) it launches fine.

Considering how it doesn't care about the system locale after all I think it's the best to just set LC_ALL=C and call it a day.