### PR TITLE
Remove PrefersNonDefaultGPU from desktop file

### DIFF
--- a/com.mojang.Minecraft.desktop
+++ b/com.mojang.Minecraft.desktop
@@ -5,4 +5,3 @@ Icon=com.mojang.Minecraft
 Exec=minecraft
 Categories=Game;
 StartupWMClass=net-minecraft-bootstrap-Bootstrap
-PrefersNonDefaultGPU=true


### PR DESCRIPTION
PrefersNonDefaultGPU is currently very broken, see https://github.com/ValveSoftware/steam-for-linux/issues/9940

initially added by https://github.com/flathub/com.mojang.Minecraft/pull/119