### PR TITLE
add wayland sock. access (suggestion)

### DIFF
--- a/com.mojang.Minecraft.yml
+++ b/com.mojang.Minecraft.yml
@@ -8,7 +8,7 @@ tags:
   - proprietary
 finish-args:
   - --persist=.minecraft
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --share=ipc
   - --device=dri

--- a/com.mojang.Minecraft.yml
+++ b/com.mojang.Minecraft.yml
@@ -9,6 +9,7 @@ tags:
 finish-args:
   - --persist=.minecraft
   - --socket=x11
+  - --socket=wayland
   - --share=ipc
   - --device=dri
   - --socket=pulseaudio


### PR DESCRIPTION
why: https://www.minecraft.net/en-us/article/minecraft-26-3-snapshot-4

edit: the linter throws error about allowing both x11 and wayland but on actual usage this should be fine, the launcher is x11 only but minecraft 26.3-snapshot-4 and above, as well as with BlazeSDL mod, uses wayland by default, but an exception (on Flathub) can be made for this